### PR TITLE
Use a jsonrpc library instead of rolling our own

### DIFF
--- a/pyls/language_server.py
+++ b/pyls/language_server.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
 import socketserver
-from .jsonrpc import JSONRPCServer
+from .server import JSONRPCServer
 from .workspace import Workspace
 
 log = logging.getLogger(__name__)

--- a/pyls/language_server.py
+++ b/pyls/language_server.py
@@ -46,7 +46,7 @@ class LanguageServer(JSONRPCServer):
     def publish_diagnostics(self, uri, diagnostics):
         log.debug("Publishing diagnostics: %s", diagnostics)
         params = {'uri': uri, 'diagnostics': diagnostics}
-        self.call(self.M_PUBLISH_DIAGNOSTICS, params)
+        self.notify(self.M_PUBLISH_DIAGNOSTICS, params)
 
     def m_initialize(self, **kwargs):
         log.debug("Language server intialized with %s", kwargs)

--- a/pyls/server.py
+++ b/pyls/server.py
@@ -25,7 +25,7 @@ class JSONRPCServer(socketserver.StreamRequestHandler, object):
         while True:
             try:
                 data = self._read_message()
-                log.info("Got message: %s", data)
+                log.debug("Got message: %s", data)
                 response = jsonrpc.JSONRPCResponseManager.handle(data, self)
                 if response is not None:
                     self._write_message(response.data)
@@ -57,9 +57,7 @@ class JSONRPCServer(socketserver.StreamRequestHandler, object):
 
     def call(self, method, params=None):
         """ Call a remote method, for now we ignore the response... """
-        req = jsonrpc.jsonrpc2.JSONRPC20Request()
-        req.method = method
-        req.params = params
+        req = jsonrpc.jsonrpc2.JSONRPC20Request(method=method, params=params, is_notification=True)
         self._write_message(req.data)
 
     def _content_length(self, line):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 configparser
 future
 jedi>=0.10
+json-rpc
 pycodestyle
 pyflakes
 yapf

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,10 @@ setup(
     install_requires=[
         'configparser',
         'future',
+        'jedi>=0.10',
+        'json-rpc',
         'pycodestyle',
         'pyflakes',
-        'jedi>=0.10',
         'yapf'
     ],
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,10 @@
 # Copyright 2017 Palantir Technologies, Inc.
 """ py.test configuration"""
+import logging
+from pyls.__main__ import LOG_FORMAT
+
+logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
+
 
 pytest_plugins = [
     'test.fixtures'

--- a/test/test_language_server.py
+++ b/test/test_language_server.py
@@ -1,8 +1,12 @@
 # Copyright 2017 Palantir Technologies, Inc.
-from threading import Thread
+import json
 import os
+from threading import Thread
+
+import jsonrpc
 import pytest
-from pyls.jsonrpc import JSONRPCServer
+
+from pyls.server import JSONRPCServer
 from pyls.language_server import start_io_lang_server
 from pyls.python_ls import PythonLanguageServer
 
@@ -47,7 +51,7 @@ def test_initialize(client_server):
         'rootPath': os.path.dirname(__file__),
         'initializationOptions': {}
     })
-    response = client._read_message()
+    response = _next_message(client)
 
     assert 'capabilities' in response['result']
 
@@ -56,14 +60,14 @@ def test_file_closed(client_server):
     client, server = client_server
     client.rfile.close()
     with pytest.raises(Exception):
-        client._read_message()
+        _next_message(client)
 
 
 def test_missing_message(client_server):
     client, server = client_server
 
     client.call('unknown_method')
-    response = client._read_message()
+    response = _next_message(client)
     assert response['error']['code'] == -32601  # Method not implemented error
 
 
@@ -76,7 +80,7 @@ def test_linting(client_server):
         'rootPath': os.path.dirname(__file__),
         'initializationOptions': {}
     })
-    response = client._read_message()
+    response = _next_message(client)
 
     assert 'capabilities' in response['result']
 
@@ -84,7 +88,11 @@ def test_linting(client_server):
     client.call('textDocument/didOpen', {
         'textDocument': {'uri': 'file:///test', 'text': 'import sys'}
     })
-    response = client._read_message()
+    response = _next_message(client)
 
     assert response['method'] == 'textDocument/publishDiagnostics'
     assert len(response['params']['diagnostics']) > 0
+
+
+def _next_message(client):
+    return json.loads(client._read_message())

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py36
+envlist = py27,py36,lint
 
 [pycodestyle]
 ignore = E226
@@ -18,10 +18,13 @@ addopts =
 
 [testenv]
 commands =
-    pycodestyle pyls
-    pyflakes pyls
-    py.test
+    py.test {posargs}
 deps =
     pytest
     coverage
     pytest-cov
+
+[testenv:lint]
+commands =
+    pycodestyle pyls
+    pyflakes pyls


### PR DESCRIPTION
Has various benefits, one such example is support for batched requests. Also makes it easier to return batches responses later when we multi-thread providers.