### PR TITLE
Bump down required python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Python Language Server
 .. image:: https://img.shields.io/github/license/palantir/python-language-server.svg
      :target: https://github.com/palantir/python-language-server/blob/master/LICENSE
 
-A Python 2.7 and 3.6 implementation of the `Language Server Protocol`_ making use of Jedi_, pycodestyle_, Pyflakes_ and YAPF_.
+A Python 2.7 and 3.4+ implementation of the `Language Server Protocol`_ making use of Jedi_, pycodestyle_, Pyflakes_ and YAPF_.
 
 Features
 --------

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   post:
-    - pyenv global 2.7.11 3.6.0
+    - pyenv global 2.7.11 3.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py36,lint
+envlist = py27,py34,lint
 
 [pycodestyle]
 ignore = E226


### PR DESCRIPTION
As discussed in https://github.com/palantir/python-language-server/pull/2, the test suite passes for me with python 3.4.3, so might as well not make it seem a more recent version is required :)