### PR TITLE
fix for signature help 

### DIFF
--- a/pyls/providers/signature.py
+++ b/pyls/providers/signature.py
@@ -22,7 +22,7 @@ class JediSignatureProvider(JediProvider):
 
         # If there are params, add those
         if len(s.params) > 0:
-            sig['params'] = [{
+            sig['parameters'] = [{
                 'label': p.name,
                 # TODO: we could do smarter things here like parsing the function docstring
                 'documentation': ""

--- a/test/providers/test_signature.py
+++ b/test/providers/test_signature.py
@@ -33,4 +33,4 @@ def test_signature(workspace):
     sigs = provider.run(DOC_URI, sig_position)['signatures']
     assert len(sigs) == 1
     assert sigs[0]['label'] == 'main(param1, param2)'
-    assert sigs[0]['params'][0]['label'] == 'param1'
+    assert sigs[0]['parameters'][0]['label'] == 'param1'


### PR DESCRIPTION
It should be `parameters` not `params`.
(see https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textDocument_signatureHelp)