### PR TITLE
Unquote parsed urls in both Workspace and Document

### DIFF
--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import sys
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse, unquote
 
 import jedi
 
@@ -25,7 +25,7 @@ class Workspace(object):
 
     def __init__(self, root, lang_server=None):
         self._url_parsed = urlparse(root)
-        self.root = self._url_parsed.path
+        self.root = unquote(self._url_parsed.path)
         self._docs = {}
         self._lang_server = lang_server
 
@@ -80,7 +80,7 @@ class Document(object):
     def __init__(self, uri, source=None, version=None, local=True, sys_path=None):
         self.uri = uri
         self.version = version
-        self.path = urlparse(uri).path
+        self.path = unquote(urlparse(uri).path)
         self.filename = os.path.basename(self.path)
 
         self._local = local

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -36,7 +36,7 @@ class Workspace(object):
         return self._docs[doc_uri]
 
     def put_document(self, doc_uri, content, version=None):
-        path = urlparse(doc_uri).path
+        path = unquote(urlparse(doc_uri).path)
         self._docs[doc_uri] = Document(
             doc_uri, content, sys_path=self.syspath_for_path(path), version=version
         )

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 RE_START_WORD = re.compile('[A-Za-z_0-9]*$')
 RE_END_WORD = re.compile('^[A-Za-z_0-9]*')
 
+
 class Workspace(object):
 
     M_PUBLISH_DIAGNOSTICS = 'textDocument/publishDiagnostics'

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 RE_START_WORD = re.compile('[A-Za-z_0-9]*$')
 RE_END_WORD = re.compile('^[A-Za-z_0-9]*')
 
-
 class Workspace(object):
 
     M_PUBLISH_DIAGNOSTICS = 'textDocument/publishDiagnostics'
@@ -24,8 +23,8 @@ class Workspace(object):
     M_SHOW_MESSAGE = 'window/showMessage'
 
     def __init__(self, root, lang_server=None):
-        self._url_parsed = urlparse(root)
-        self.root = unquote(self._url_parsed.path)
+        self._url_parsed = urlparse(unquote(root))
+        self.root = self._url_parsed.path
         self._docs = {}
         self._lang_server = lang_server
 

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -2,7 +2,6 @@
 import os
 import pytest
 from pyls import workspace
-from pyls.workspace import Workspace
 
 DOC_URI = 'file://' + __file__
 
@@ -57,7 +56,7 @@ def test_non_root_project(pyls):
 def test_urlencoded_paths():
     root_uri = "file:///Encoded%20Space/"
     file_uri = root_uri + "test.py"
-    ws = Workspace(root_uri)
+    ws = workspace.Workspace(root_uri)
     assert ws.root == "/Encoded Space/"
     ws.put_document(file_uri, "")
     doc = ws.get_document(file_uri)

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -2,6 +2,7 @@
 import os
 import pytest
 from pyls import workspace
+from pyls.workspace import Workspace
 
 DOC_URI = 'file://' + __file__
 
@@ -51,3 +52,13 @@ def test_non_root_project(pyls):
     pyls.workspace.put_document(test_uri, 'assert True')
     test_doc = pyls.workspace.get_document(test_uri)
     assert project_root in pyls.workspace.syspath_for_path(test_doc.path)
+
+
+def test_urlencoded_paths():
+    root_uri = "file:///Encoded%20Space/"
+    file_uri = root_uri + "test.py"
+    ws = Workspace(root_uri)
+    assert ws.root == "/Encoded Space/"
+    ws.put_document(file_uri, "")
+    doc = ws.get_document(file_uri)
+    assert doc.path == '/Encoded Space/test.py'


### PR DESCRIPTION
Naïve fix for #79, where document URIs containing encoded spaces (`%20`) were not url decoded before being passed to Jedi.

Fix also applied to Workspace, as it is already written to handle URIs.

- [x] Test added for workspace and document