### PR TITLE
Support rootUri (LSP 3.0) with rootPath fallback

### DIFF
--- a/pyls/config.py
+++ b/pyls/config.py
@@ -3,6 +3,7 @@ from configparser import RawConfigParser
 import logging
 import os
 import pluggy
+from urllib.parse import urlparse, unquote
 
 from . import hookspecs, PYLS
 
@@ -11,8 +12,8 @@ log = logging.getLogger(__name__)
 
 class Config(object):
 
-    def __init__(self, root_path, init_opts):
-        self._root_path = root_path
+    def __init__(self, root_uri, init_opts):
+        self._root_path = unquote(urlparse(root_uri).path)
         self._init_opts = init_opts
 
         self._pm = pluggy.PluginManager(PYLS)

--- a/pyls/config.py
+++ b/pyls/config.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 class Config(object):
 
     def __init__(self, root_uri, init_opts):
-        self._root_path = unquote(urlparse(root_uri).path)
+        self._root_uri = root_uri
         self._init_opts = init_opts
 
         self._pm = pluggy.PluginManager(PYLS)
@@ -31,11 +31,12 @@ class Config(object):
         return self._init_opts
 
     @property
-    def root_path(self):
-        return self._root_path
+    def root_uri(self):
+        return self._root_uri
 
     def find_parents(self, path, names):
-        return find_parents(self.root_path, path, names)
+        root_path = unquote(urlparse(self._root_uri).path)
+        return find_parents(root_path, path, names)
 
 
 def build_config(key, config_files):

--- a/pyls/language_server.py
+++ b/pyls/language_server.py
@@ -89,10 +89,10 @@ class LanguageServer(MethodJSONRPCServer):
     def m_initialize(self, **kwargs):
         log.debug("Language server intialized with %s", kwargs)
         if 'rootUri' in kwargs:
-            self.root_uri = kwargs.get('rootUri')
+            self.root_uri = kwargs['rootUri']
         elif 'rootPath' in kwargs:
-            root_path = kwargs.get('rootPath')
-            self.root_uri = urljoin(u'file:', pathname2url(root_path))
+            root_path = kwargs['rootPath']
+            self.root_uri = urljoin(u'file://', pathname2url(root_path))
         else:
             self.root_uri = ''
         self.init_opts = kwargs.get('initializationOptions')

--- a/pyls/language_server.py
+++ b/pyls/language_server.py
@@ -3,6 +3,8 @@ import logging
 import re
 import socketserver
 from .server import JSONRPCServer
+from urllib.parse import urljoin
+from urllib.request import pathname2url
 
 log = logging.getLogger(__name__)
 
@@ -75,22 +77,28 @@ class LanguageServer(MethodJSONRPCServer):
     """
 
     process_id = None
-    root_path = None
+    root_uri = None
     init_opts = None
 
     def capabilities(self):
         return {}
 
-    def initialize(self, root_path, init_opts, process_id):
+    def initialize(self, root_uri, init_opts, process_id):
         pass
 
     def m_initialize(self, **kwargs):
         log.debug("Language server intialized with %s", kwargs)
-        self.root_path = kwargs.get('rootPath')
+        if 'rootUri' in kwargs:
+            self.root_uri = kwargs.get('rootUri')
+        elif 'rootPath' in kwargs:
+            root_path = kwargs.get('rootPath')
+            self.root_uri = urljoin(u'file:', pathname2url(root_path))
+        else:
+            self.root_uri = ''
         self.init_opts = kwargs.get('initializationOptions')
         self.process_id = kwargs.get('processId')
 
-        self.initialize(self.root_path, self.init_opts, self.process_id)
+        self.initialize(self.root_uri, self.init_opts, self.process_id)
 
         # Get our capabilities
         return {'capabilities': self.capabilities()}

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlparse, unquote
 
 from . import config, lsp, plugins
 from .language_server import LanguageServer
@@ -39,8 +40,10 @@ class PythonLanguageServer(LanguageServer):
             'textDocumentSync': lsp.TextDocumentSyncKind.INCREMENTAL
         }
 
-    def initialize(self, root_path, init_opts, _process_id):
-        self.workspace = Workspace(root_path, lang_server=self)
+    def initialize(self, root_uri, init_opts, _process_id):
+        self.workspace = Workspace(root_uri, lang_server=self)
+
+        root_path = unquote(urlparse(root_uri).path)
         self.config = config.Config(root_path, init_opts)
 
         # Register the base set of plugins

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -1,6 +1,4 @@
 import logging
-from urllib.parse import urlparse, unquote
-
 from . import config, lsp, plugins
 from .language_server import LanguageServer
 from .workspace import Workspace
@@ -42,9 +40,7 @@ class PythonLanguageServer(LanguageServer):
 
     def initialize(self, root_uri, init_opts, _process_id):
         self.workspace = Workspace(root_uri, lang_server=self)
-
-        root_path = unquote(urlparse(root_uri).path)
-        self.config = config.Config(root_path, init_opts)
+        self.config = config.Config(root_uri, init_opts)
 
         # Register the base set of plugins
         # TODO(gatesn): Make these configurable in init_opts

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -23,8 +23,8 @@ class Workspace(object):
     M_APPLY_EDIT = 'workspace/applyEdit'
     M_SHOW_MESSAGE = 'window/showMessage'
 
-    def __init__(self, root, lang_server=None):
-        self._url_parsed = urlparse(root)
+    def __init__(self, root_uri, lang_server=None):
+        self._url_parsed = urlparse(root_uri)
         self.root = unquote(self._url_parsed.path)
         self._docs = {}
         self._lang_server = lang_server

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -37,4 +37,4 @@ def workspace():
 @pytest.fixture
 def config(workspace):
     """Return a config object."""
-    return Config(workspace.root, {})
+    return Config(path2uri(os.path.dirname(__file__)), {})

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -5,7 +5,12 @@ from pyls.config import Config
 from pyls.python_ls import PythonLanguageServer
 from pyls.workspace import Workspace
 from io import StringIO
+from urllib.parse import urljoin
+from urllib.request import pathname2url
 
+
+def path2uri(path):
+    return urljoin(u"file://", pathname2url(path))
 
 @pytest.fixture
 def pyls(tmpdir):
@@ -16,7 +21,7 @@ def pyls(tmpdir):
 
     ls.m_initialize(
         processId=1,
-        rootPath=str(tmpdir),
+        rootUri=path2uri(str(tmpdir)),
         initializationOptions={}
     )
 
@@ -26,7 +31,7 @@ def pyls(tmpdir):
 @pytest.fixture
 def workspace():
     """Return a workspace."""
-    return Workspace(os.path.dirname(__file__))
+    return Workspace(path2uri(os.path.dirname(__file__)))
 
 
 @pytest.fixture


### PR DESCRIPTION
This makes rootUri the default format for the workspace directory, where rootPath is accepted and converted to a url in the initialize handler.

As discussed in #56, this is the major change from protocol version 2 to 3.