### PR TITLE
Fix edits that occur at the end of the file

### DIFF
--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -92,9 +92,7 @@ class Document(object):
 
     @property
     def lines(self):
-        # An empty document is much nicer to deal with assuming it has a single
-        # line with no characters and no final newline.
-        return self.source.splitlines(True) or [u'']
+        return self.source.splitlines(True)
 
     @property
     def source(self):
@@ -118,7 +116,13 @@ class Document(object):
         end_line = change_range['end']['line']
         end_col = change_range['end']['character']
 
+        # Check for an edit occuring at the very end of the file
+        if start_line == len(self.lines):
+            self._source = self.source + text
+            return
+
         new = io.StringIO()
+
         # Iterate over the existing document until we hit the edit range,
         # at which point we write the new text, then loop until we hit
         # the end of the range and continue writing.

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -77,3 +77,20 @@ def test_document_multiline_edit():
         "def hello(a, b):\n",
         "    print a, b\n"
     ]
+
+
+def test_document_end_of_file_edit():
+    old = [
+        "print 'a'\n",
+        "print 'b'\n"
+    ]
+    doc = Document('file:///uri', u''.join(old))
+    doc.apply_change({'text': u'o', 'range': {
+        'start': {'line': 2, 'character': 0},
+        'end': {'line': 2, 'character': 0}
+    }})
+    assert doc.lines == [
+        "print 'a'\n",
+        "print 'b'\n",
+        "o",
+    ]


### PR DESCRIPTION
We had previously special-cased an empty file by creating an empty line. 

But the case was more general and happens whenever edits occur at the very end of a file. 

We remove the special case for empty, and instead special case end-of-file edits. This is because when we enumerate `lines`, we stop enumerating 1 before the change line!