### PR TITLE
Jedi symbols: Add all_scopes config option

### DIFF
--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 @hookimpl
 def pyls_document_symbols(config, document):
-    all_scopes = config.plugin_settings('jedi_symbols').get('all_scopes', False)
+    all_scopes = config.plugin_settings('jedi_symbols').get('all_scopes', True)
     definitions = document.jedi_names(all_scopes=all_scopes)
     return [{
         'name': d.name,

--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -7,8 +7,9 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl
-def pyls_document_symbols(document):
-    definitions = document.jedi_names()
+def pyls_document_symbols(config, document):
+    all_scopes = config.plugin_settings('jedi_symbols').get('all_scopes', False)
+    definitions = document.jedi_names(all_scopes=all_scopes)
     return [{
         'name': d.name,
         'kind': _kind(d),

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -20,6 +20,7 @@ def main():
 
 def test_symbols(config):
     doc = Document(DOC_URI, DOC)
+    config.update({'plugins': {'jedi_symbols': {'all_scopes': False}}})
     symbols = pyls_document_symbols(config, doc)
 
     # All four symbols (import sys, a, B, main)
@@ -40,7 +41,6 @@ def test_symbols(config):
 
 def test_symbols_alls_scopes(config):
     doc = Document(DOC_URI, DOC)
-    config.update({'plugins': {'jedi_symbols': {'all_scopes': True}}})
     symbols = pyls_document_symbols(config, doc)
 
     # All five symbols (import sys, a, B, __init__, main)

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -17,9 +17,9 @@ def main():
 """
 
 
-def test_symbols():
+def test_symbols(config):
     doc = Document(DOC_URI, DOC)
-    symbols = pyls_document_symbols(doc)
+    symbols = pyls_document_symbols(config, doc)
 
     # All four symbols (import sys, a, B, main)
     assert len(symbols) == 4

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -9,8 +9,9 @@ DOC = """import sys
 
 a = 'hello'
 
-class B(object):
-    pass
+class B:
+    def __init__():
+        pass
 
 def main():
     pass
@@ -31,6 +32,28 @@ def test_symbols(config):
     assert sym('sys')['kind'] == SymbolKind.Module
     assert sym('a')['kind'] == SymbolKind.Variable
     assert sym('B')['kind'] == SymbolKind.Class
+    assert sym('main')['kind'] == SymbolKind.Function
+
+    # Not going to get too in-depth here else we're just testing Jedi
+    assert sym('a')['location']['range']['start'] == {'line': 2, 'character': 0}
+
+
+def test_symbols_alls_scopes(config):
+    doc = Document(DOC_URI, DOC)
+    config.update({'plugins': {'jedi_symbols': {'all_scopes': True}}})
+    symbols = pyls_document_symbols(config, doc)
+
+    # All five symbols (import sys, a, B, __init__, main)
+    assert len(symbols) == 5
+
+    def sym(name):
+        return [s for s in symbols if s['name'] == name][0]
+
+    # Check we have some sane mappings to VSCode constants
+    assert sym('sys')['kind'] == SymbolKind.Module
+    assert sym('a')['kind'] == SymbolKind.Variable
+    assert sym('B')['kind'] == SymbolKind.Class
+    assert sym('__init__')['kind'] == SymbolKind.Function
     assert sym('main')['kind'] == SymbolKind.Function
 
     # Not going to get too in-depth here else we're just testing Jedi

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -50,6 +50,11 @@
                     "default": true,
                     "description": "Enable or disable the plugin."
                 },
+                "pyls.plugins.jedi_symbols.all_scopes": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If True lists the names of all scopes instead of only the module namespace."
+                },
                 "pyls.plugins.mccabe.enabled": {
                     "type": "boolean",
                     "default": true,

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -52,7 +52,7 @@
                 },
                 "pyls.plugins.jedi_symbols.all_scopes": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "If True lists the names of all scopes instead of only the module namespace."
                 },
                 "pyls.plugins.mccabe.enabled": {


### PR DESCRIPTION
This PR adds a new config option to allow users to configure if symbols from all scopes are shown or not.

This was originally brought up on the `ide-python` package for Atom: https://github.com/lgeiger/ide-python/issues/11 

## `all_scopes=false` (default / old behavior)
<img width="656" alt="all_scopes=false (default)" src="https://user-images.githubusercontent.com/13285808/30754882-c6cf7614-9fc4-11e7-97e3-1353f9e8600f.png">

## `all_scopes=true`
<img width="658" alt=" all_scopes=true" src="https://user-images.githubusercontent.com/13285808/30754895-d3b36e9e-9fc4-11e7-9ba4-92e774305a58.png">

**Note:** I'm using Atom to test this and haven't tried the VSCode plugin, but judging from the existing config options this should work as expected.