### PR TITLE
Use goto assignment instead of goto definition

### DIFF
--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -7,14 +7,15 @@ log = logging.getLogger(__name__)
 
 @hookimpl
 def pyls_definitions(document, position):
-    definitions = document.jedi_script(position).goto_definitions()
+    definitions = document.jedi_script(position).goto_assignments()
+
     definitions = [
         d for d in definitions
-        if d.is_definition() and d.line is not None and d.column is not None
+        if d.is_definition() and d.line is not None and d.column is not None and d.module_path is not None
     ]
 
     return [{
-        'uri': uris.uri_with(document.uri, path=d.module_path) if d.module_path else document.uri,
+        'uri': uris.uri_with(document.uri, path=d.module_path),
         'range': {
             'start': {'line': d.line - 1, 'character': d.column},
             'end': {'line': d.line - 1, 'character': d.column + len(d.name)}

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -8,6 +8,14 @@ DOC = """def a():
     pass
 
 print a()
+
+
+class Directory(object):
+    def __init__(self):
+        self.members = dict()
+
+    def add_member(self, id, name):
+        self.members[id] = name
 """
 
 
@@ -19,6 +27,29 @@ def test_definitions():
     range = {
         'start': {'line': 0, 'character': 4},
         'end': {'line': 0, 'character': 5}
+    }
+
+    doc = Document(DOC_URI, DOC)
+    assert [{'uri': DOC_URI, 'range': range}] == pyls_definitions(doc, cursor_pos)
+
+
+def test_builtin_definition():
+    # Over 'i' in dict
+    cursor_pos = {'line': 8, 'character': 24}
+
+    # No go-to def for builtins
+    doc = Document(DOC_URI, DOC)
+    assert [] == pyls_definitions(doc, cursor_pos)
+
+
+def test_assignment():
+    # Over 's' in self.members[id]
+    cursor_pos = {'line': 11, 'character': 19}
+
+    # The assignment of 'self.members'
+    range = {
+        'start': {'line': 8, 'character': 13},
+        'end': {'line': 8, 'character': 20}
     }
 
     doc = Document(DOC_URI, DOC)


### PR DESCRIPTION
As suggested in #154.

Changes the following behaviour (with tests)
* Go to definition on a builtin (eg. `dict`) will no longer send you to a random location in the current document (Jedi gives no valid destination)
* Go to definition on the second`my_dict` below would assume you want to go to the definition of the `dict` builtin. Now it will send you to the `my_dict` assignment on the first line.  

```python
my_dict = dict()

my_dict['key'] = "val"
```