### PR TITLE
pycodestyle config: convert arrays to comma seperated strings

### DIFF
--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -23,3 +23,7 @@ def debounce(interval_s):
 def camel_to_underscore(string):
     s1 = FIRST_CAP_RE.sub(r'\1_\2', string)
     return ALL_CAP_RE.sub(r'\1_\2', s1).lower()
+
+
+def list_to_string(value):
+    return ",".join(value) if type(value) == list else value

--- a/pyls/plugins/pycodestyle_lint.py
+++ b/pyls/plugins/pycodestyle_lint.py
@@ -26,7 +26,7 @@ def pyls_lint(config, document):
 
     # Then, read the PYLS configuration
     ide_conf = config.plugin_settings('pycodestyle')
-    conf.update({_utils.camel_to_underscore(k): v for k, v in ide_conf.items()})
+    conf.update({_utils.camel_to_underscore(k): _utils.list_to_string(v) for k, v in ide_conf.items()})
 
     # Finally, read the project configuration
     conf.update(_config_from_files(config.find_parents(document.path, CONFIG_FILES)))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -24,3 +24,13 @@ def test_debounce():
     time.sleep(interval * 2)
     call_m()
     assert call_m._count == 2
+
+
+def test_list_to_string():
+    assert _utils.list_to_string("string") == "string"
+    assert _utils.list_to_string(["a", "r", "r", "a", "y"]) == "a,r,r,a,y"
+
+
+def test_camel_to_underscore():
+    assert _utils.camel_to_underscore("camelCase") == "camel_case"
+    assert _utils.camel_to_underscore("under_score") == "under_score"


### PR DESCRIPTION
This fixes https://github.com/palantir/python-language-server/pull/156#issuecomment-334129877 since pycodestyle expects the config values as a comma separated string.

Unfortunately ignoring a specific error code still doesn't work correctly, all errors are ignored instead. The same happens for warnings too. Any idea why this is happening?

Fixes #156 