### PR TITLE
add error severity to pyflakes

### DIFF
--- a/pyls/plugins/pyflakes_lint.py
+++ b/pyls/plugins/pyflakes_lint.py
@@ -27,7 +27,8 @@ class PyflakesDiagnosticReport(object):
         self.diagnostics.append({
             'source': 'pyflakes',
             'range': range,
-            'message': msg
+            'message': msg,
+            'severity': lsp.DiagnosticSeverity.Error,
         })
 
     def flake(self, message):


### PR DESCRIPTION
This was previously missing and it was up to the clients to decide the severity, however its better to be explicit that this is an error.