### PR TITLE
Completion detail using module name, function parameters

### DIFF
--- a/pyls/plugins/completion.py
+++ b/pyls/plugins/completion.py
@@ -10,12 +10,21 @@ log = logging.getLogger(__name__)
 def pyls_completions(document, position):
     definitions = document.jedi_script(position).completions()
     return [{
-        'label': d.name,
+        'label': _label(d),
         'kind': _kind(d),
         'detail': _detail(d),
         'documentation': d.docstring(),
-        'sortText': _sort_text(d)
+        'sortText': _sort_text(d),
+        'insertText': d.name
     } for d in definitions]
+
+
+def _label(definition):
+    if definition.type in ('function', 'method'):
+        params = ", ".join(map(lambda definition: definition.name, definition.params))
+        return "{}({})".format(definition.name, params)
+
+    return definition.name
 
 
 def _detail(definition):

--- a/pyls/plugins/completion.py
+++ b/pyls/plugins/completion.py
@@ -12,10 +12,14 @@ def pyls_completions(document, position):
     return [{
         'label': d.name,
         'kind': _kind(d),
-        'detail': d.description or "",
+        'detail': _detail(d),
         'documentation': d.docstring(),
         'sortText': _sort_text(d)
     } for d in definitions]
+
+
+def _detail(definition):
+    return "builtin" if definition.in_builtin_module() else definition.parent().full_name or ""
 
 
 def _sort_text(definition):

--- a/pyls/plugins/completion.py
+++ b/pyls/plugins/completion.py
@@ -21,7 +21,7 @@ def pyls_completions(document, position):
 
 def _label(definition):
     if definition.type in ('function', 'method'):
-        params = ", ".join(map(lambda definition: definition.name, definition.params))
+        params = ", ".join(param.name for param in definition.params)
         return "{}({})".format(definition.name, params)
 
     return definition.name

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -1,4 +1,5 @@
 # Copyright 2017 Palantir Technologies, Inc.
+import sys
 from pyls import uris
 from pyls.plugins.completion import pyls_completions
 from pyls.workspace import Document
@@ -23,7 +24,10 @@ def test_completion():
     items = pyls_completions(doc, com_position)
 
     assert len(items) > 0
-    assert items[0]['label'] == 'read()'
+    if (sys.version_info > (3, 0)):
+        assert items[0]['label'] == 'read(args)'
+    else:
+        assert items[0]['label'] == 'read()'
 
 
 def test_completion_ordering():

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -23,7 +23,7 @@ def test_completion():
     items = pyls_completions(doc, com_position)
 
     assert len(items) > 0
-    assert items[0]['label'] == 'read'
+    assert items[0]['label'] == 'read(args)'
 
 
 def test_completion_ordering():
@@ -35,6 +35,6 @@ def test_completion_ordering():
     items = {c['label']: c['sortText'] for c in completions}
 
     # Assert that builtins come after our own functions even if alphabetically they're before
-    assert items['hello'] < items['dict']
+    assert items['hello()'] < items['dict']
     # And that 'hidden' functions come after unhidden ones
-    assert items['hello'] < items['_a_hello']
+    assert items['hello()'] < items['_a_hello()']

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -23,7 +23,7 @@ def test_completion():
     items = pyls_completions(doc, com_position)
 
     assert len(items) > 0
-    assert items[0]['label'] == 'read(args)'
+    assert items[0]['label'] == 'read()'
 
 
 def test_completion_ordering():


### PR DESCRIPTION
Here are some explorations for #149 for testing / discussion. Likely to conflict with the Rope integration, but this is far from decided anyways.

<img width="658" alt="screen shot 2017-10-01 at 20 30 42" src="https://user-images.githubusercontent.com/4395832/31057691-7230942e-a6e7-11e7-877f-bcd597dd8495.png">

Performance is okay for me in a small codebase, anyone working with a large code base who can do a quick comparison?
References to Jedi implementations:

Signature params: https://github.com/davidhalter/jedi/blob/752b7d8d495689a38076f20475a870f8aa139a28/jedi/api/classes.py#L314

Full_name:
https://github.com/davidhalter/jedi/blob/752b7d8d495689a38076f20475a870f8aa139a28/jedi/api/classes.py#L265