### PR TITLE
Hierarchical symbols

### DIFF
--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -10,7 +10,6 @@ log = logging.getLogger(__name__)
 def pyls_document_symbols(config, document):
     all_scopes = config.plugin_settings('jedi_symbols').get('all_scopes', True)
     definitions = document.jedi_names(all_scopes=all_scopes)
-    print definitions[0].name, definitions[0].type
     return [{
         'name': d.name,
         'containerName': _container(d),

--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -22,11 +22,11 @@ def pyls_document_symbols(config, document):
 
 
 def _include_def(definition):
+    log.info("Definition %s has parent %s", definition.name, definition.parent().name)
     return (
         # Don't tend to include parameters as symbols
         definition.type != 'param' and
-        # Only include symbols that have a parent
-        _container(definition) is not None and
+        # Unused vars should also be skipped
         definition.name != '_' and
         _kind(definition) is not None
     )
@@ -36,9 +36,12 @@ def _container(definition):
     try:
         # Jedi sometimes fails here.
         parent = definition.parent()
-        return parent.name
+        # Here we check that a grand-parent exists to avoid declaring symbols
+        # as children of the module.
+        if parent.parent():
+            return parent.name
     except:
-        parent = None
+        pass
 
 
 def _range(definition):

--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -25,6 +25,8 @@ def _include_def(definition):
     return (
         # Don't tend to include parameters as symbols
         definition.type != 'param' and
+        # Only include symbols that have a parent
+        _container(definition) is not None and
         definition.name != '_' and
         _kind(definition) is not None
     )

--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -22,7 +22,6 @@ def pyls_document_symbols(config, document):
 
 
 def _include_def(definition):
-    log.info("Definition %s has parent %s", definition.name, definition.parent().name)
     return (
         # Don't tend to include parameters as symbols
         definition.type != 'param' and

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -26,8 +26,8 @@ def test_symbols(config):
     config.update({'plugins': {'jedi_symbols': {'all_scopes': False}}})
     symbols = pyls_document_symbols(config, doc)
 
-    # All four symbols (import sys, a, B, main)
-    assert len(symbols) == 4
+    # All four symbols (import sys, a, B, main, y)
+    assert len(symbols) == 5
 
     def sym(name):
         return [s for s in symbols if s['name'] == name][0]
@@ -45,9 +45,8 @@ def test_symbols_all_scopes(config):
     doc = Document(DOC_URI, DOC)
     symbols = pyls_document_symbols(config, doc)
 
-    # All five symbols (import sys, a, B, __init__, main)
-    raise Exception([s['name'] for s in symbols])
-    assert len(symbols) == 5
+    # All eight symbols (import sys, a, B, __init__, x, y, main, y)
+    assert len(symbols) == 8
 
     def sym(name):
         return [s for s in symbols if s['name'] == name][0]

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -10,11 +10,14 @@ DOC = """import sys
 a = 'hello'
 
 class B:
-    def __init__():
-        pass
+    def __init__(self):
+        x = 2
+        self.y = x
 
-def main():
-    pass
+def main(x):
+    y = 2 * x
+    return y
+
 """
 
 

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -33,7 +33,6 @@ def test_symbols(config):
         return [s for s in symbols if s['name'] == name][0]
 
     # Check we have some sane mappings to VSCode constants
-    assert sym('sys')['kind'] == SymbolKind.Module
     assert sym('a')['kind'] == SymbolKind.Variable
     assert sym('B')['kind'] == SymbolKind.Class
     assert sym('main')['kind'] == SymbolKind.Function
@@ -42,18 +41,18 @@ def test_symbols(config):
     assert sym('a')['location']['range']['start'] == {'line': 2, 'character': 0}
 
 
-def test_symbols_alls_scopes(config):
+def test_symbols_all_scopes(config):
     doc = Document(DOC_URI, DOC)
     symbols = pyls_document_symbols(config, doc)
 
     # All five symbols (import sys, a, B, __init__, main)
+    raise Exception([s['name'] for s in symbols])
     assert len(symbols) == 5
 
     def sym(name):
         return [s for s in symbols if s['name'] == name][0]
 
     # Check we have some sane mappings to VSCode constants
-    assert sym('sys')['kind'] == SymbolKind.Module
     assert sym('a')['kind'] == SymbolKind.Variable
     assert sym('B')['kind'] == SymbolKind.Class
     assert sym('__init__')['kind'] == SymbolKind.Function


### PR DESCRIPTION
@lgeiger want to decide on what the symbols look like:

```
import sys

a = 'hello'

class B:
    def __init__(self):
        x = 2
        self.y = x

def main(x):
    y = 2 * x
    return y
```

IMO:

- `sys`
- `a`
- `B`
- `B.__init__`
- `B.__init__.x`
- `main`
- `main.y`