### PR TITLE
remove .exit() call on KeyboardInterrupt

### DIFF
--- a/pyls/language_server.py
+++ b/pyls/language_server.py
@@ -36,8 +36,6 @@ def start_tcp_lang_server(bind_addr, port, handler_class):
     try:
         log.info("Serving %s on (%s, %s)", handler_class.__name__, bind_addr, port)
         server.serve_forever()
-    except KeyboardInterrupt:
-        server.exit()
     finally:
         log.info("Shutting down")
         server.server_close()


### PR DESCRIPTION
`socketserver.ThreadingTCPServer` does not seem to have an `.exit` method:

```
Traceback (most recent call last):
  File "/Users/karol/git/python-language-server/venv/lib/python3.6/site-packages/pyls/language_server.py", line 38, in start_tcp_lang_server
    server.serve_forever()
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/socketserver.py", line 236, in serve_forever
    ready = selector.select(poll_interval)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/selectors.py", line 376, in select
    fd_event_list = self._poll.poll(timeout)
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/karol/git/python-language-server/venv/bin/pyls", line 11, in <module>
    sys.exit(main())
  File "/Users/karol/git/python-language-server/venv/lib/python3.6/site-packages/pyls/__main__.py", line 68, in main
    language_server.start_tcp_lang_server(args.host, args.port, PythonLanguageServer)
  File "/Users/karol/git/python-language-server/venv/lib/python3.6/site-packages/pyls/language_server.py", line 40, in start_tcp_lang_server
    server.exit()
AttributeError: 'ThreadingTCPServer' object has no attribute 'exit'
```

I think it is OK to not catch `KeyboardInterrupt` at all and just die (which will disconnect the socket obviously), wdyt?