### PR TITLE
[Auto Complete] force return None if empty array is returned

### DIFF
--- a/pyls/plugins/rope_completion.py
+++ b/pyls/plugins/rope_completion.py
@@ -41,9 +41,7 @@ def pyls_completions(document, position):
             'sortText': _sort_text(d)})
     definitions = new_definitions
     log.debug('Rope finished')
-    if len(definitions) == 0:
-        return None
-    return definitions
+    return definitions or None
 
 
 def _sort_text(definition):

--- a/pyls/plugins/rope_completion.py
+++ b/pyls/plugins/rope_completion.py
@@ -41,6 +41,8 @@ def pyls_completions(document, position):
             'sortText': _sort_text(d)})
     definitions = new_definitions
     log.debug('Rope finished')
+    if len(definitions) == 0:
+        return None
     return definitions
 
 


### PR DESCRIPTION
# Summary
`race_hooks` says it's `returning the first non-None result`, but in the implementations on auto complete the `rope_completion` return empty array instead of None, while `jedi_completion` might return non empty value.
This PR is to force return `None` for empty result from `rope_completion` to let `jedi_completion` finished, and might gives better completions.

related : #199 