### PR TITLE
Fix character normalization

### DIFF
--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -126,3 +126,10 @@ def format_docstring(contents):
     contents = contents.replace('  ', u'\u00A0' * 2)
     contents = contents.replace('*', '\\*')
     return contents
+
+
+def clip_column(column, lines, line_number):
+    # Normalise the position as per the LSP that accepts character positions > line length
+    # https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#position
+    max_column = len(lines[line_number]) - 1 if len(lines) > line_number else 0
+    return min(column, max_column)

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -267,6 +267,6 @@ class Document(object):
 
             # Normalise the position as per the LSP that accepts character positions > line length
             # https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#position
-            line_len = len(self.lines[position['line']])
-            kwargs['column'] = min(position['character'], line_len - 1)
+            max_column = len(self.lines[position['line']]) - 1 if len(self.lines) > position['line'] else 0
+            kwargs['column'] = min(position['character'], max_column)
         return jedi.Script(**kwargs)

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -264,9 +264,5 @@ class Document(object):
         }
         if position:
             kwargs['line'] = position['line'] + 1
-
-            # Normalise the position as per the LSP that accepts character positions > line length
-            # https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#position
-            max_column = len(self.lines[position['line']]) - 1 if len(self.lines) > position['line'] else 0
-            kwargs['column'] = min(position['character'], max_column)
+            kwargs['column'] = _utils.clip_column(position['character'], self.lines, position['line'])
         return jedi.Script(**kwargs)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -49,3 +49,9 @@ def test_merge_dicts():
         {'a': True, 'b': {'x': 123, 'y': {'hello': 'world'}}},
         {'a': False, 'b': {'y': [], 'z': 987}}
     ) == {'a': False, 'b': {'x': 123, 'y': [], 'z': 987}}
+
+
+def test_clip_column():
+    assert _utils.clip_column(5, ['123'], 0) == 2
+    assert _utils.clip_column(2, ['\n', '123'], 1) == 2
+    assert _utils.clip_column(0, [], 0) == 0


### PR DESCRIPTION
The language server will throw a exception if a request is sent from an empty document because `self.lines == []` and therefor `self.lines[0]` will throw `IndexError: list index out of range`.