### PR TITLE
Fixed pydocstyle_lint.py showing one diagnostic error per line,

### DIFF
--- a/pyls/plugins/pydocstyle_lint.py
+++ b/pyls/plugins/pydocstyle_lint.py
@@ -38,7 +38,7 @@ def pyls_lint(document):
             # In the case we cannot parse the Python file, just continue
             pass
 
-    log.info("Got pydocstyle errors: %s", diags)
+    log.debug("Got pydocstyle errors: %s", diags)
     return diags
 
 

--- a/pyls/plugins/pydocstyle_lint.py
+++ b/pyls/plugins/pydocstyle_lint.py
@@ -38,11 +38,11 @@ def pyls_lint(document):
             # In the case we cannot parse the Python file, just continue
             pass
 
+    log.info("Got pydocstyle errors: %s", diags)
     return diags
 
 
 def _parse_diagnostic(document, error):
-    log.info("Got error: %s", error)
     lineno = error.definition.start - 1
     line = document.lines[0] if document.lines else ""
 


### PR DESCRIPTION
instead of show all of the at once.