### PR TITLE
Replace the logging.basicConfig by a proper configuration

### DIFF
--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -65,6 +65,7 @@ def _binary_stdio():
     PY3K = sys.version_info >= (3, 0)
 
     if PY3K:
+        # pylint: disable=no-member
         stdin, stdout = sys.stdin.buffer, sys.stdout.buffer
     else:
         # Python 2 on Windows opens sys.stdin in text mode, and
@@ -89,7 +90,7 @@ def _configure_logger(args):
             logging.config.dictConfig(json.load(f))
     else:
         log_file = args.log_file
-        formatter = logging.Formatter(LOG_FORMAT, style="%")
+        formatter = logging.Formatter(LOG_FORMAT)
         if log_file:
             log_handler = logging.handlers.RotatingFileHandler(
                 log_file, mode='a', maxBytes=50*1024*1024,

--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -4,6 +4,7 @@ import json
 import logging
 import logging.config
 import sys
+
 from . import language_server
 from .python_ls import PythonLanguageServer
 
@@ -81,15 +82,13 @@ def _binary_stdio():
 
     return stdin, stdout
 
-def _configure_logger(args):
-    log_config = args.log_config
+def _configure_logger(verbose=0, log_config=None, log_file=None):
     root_logger = logging.root
 
     if log_config:
         with open(log_config, 'r') as f:
             logging.config.dictConfig(json.load(f))
     else:
-        log_file = args.log_file
         formatter = logging.Formatter(LOG_FORMAT)
         if log_file:
             log_handler = logging.handlers.RotatingFileHandler(
@@ -101,18 +100,11 @@ def _configure_logger(args):
         log_handler.setFormatter(formatter)
         root_logger.addHandler(log_handler)
 
-    # CRITICAL = 50
-    # FATAL = CRITICAL
-    # ERROR = 40
-    # WARNING = 30
-    # INFO = 20
-    # DEBUG = 10
-    if args.verbose == 0:
+    if verbose == 0:
         level = logging.WARNING
-    elif args.verbose == 1:
+    elif verbose == 1:
         level = logging.INFO
-    elif args.verbose >= 2:
+    elif verbose >= 2:
         level = logging.DEBUG
 
     root_logger.setLevel(level)
-

--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -47,7 +47,7 @@ def main():
     parser = argparse.ArgumentParser()
     add_arguments(parser)
     args = parser.parse_args()
-    configure_logger(args)
+    _configure_logger(args)
 
     if args.tcp:
         language_server.start_tcp_lang_server(args.host, args.port, PythonLanguageServer)
@@ -81,7 +81,7 @@ def _binary_stdio():
 
     return stdin, stdout
 
-def configure_logger(args):
+def _configure_logger(args):
     log_config = args.log_config
     root_logger = logging.root
 
@@ -92,8 +92,10 @@ def configure_logger(args):
         log_file = args.log_file
         formatter = logging.Formatter(LOG_FORMAT, style="%")
         if log_file:
-            log_handler = logging.handlers.RotatingFileHandler(log_file, mode='a',
-                    maxBytes=50*1024*1024, backupCount=10, encoding=None, delay=0)
+            log_handler = logging.handlers.RotatingFileHandler(
+                log_file, mode='a', maxBytes=50*1024*1024,
+                backupCount=10, encoding=None, delay=0
+            )
         else:
             log_handler = logging.StreamHandler()
         log_handler.setFormatter(formatter)

--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -65,7 +65,6 @@ def _binary_stdio():
     PY3K = sys.version_info >= (3, 0)
 
     if PY3K:
-        # pylint: disable=no-member
         stdin, stdout = sys.stdin.buffer, sys.stdout.buffer
     else:
         # Python 2 on Windows opens sys.stdin in text mode, and
@@ -115,4 +114,3 @@ def _configure_logger(args):
         level = logging.DEBUG
 
     root_logger.setLevel(level)
-

--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -115,3 +115,4 @@ def _configure_logger(args):
         level = logging.DEBUG
 
     root_logger.setLevel(level)
+

--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -82,6 +82,7 @@ def _binary_stdio():
 
     return stdin, stdout
 
+
 def _configure_logger(verbose=0, log_config=None, log_file=None):
     root_logger = logging.root
 

--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -47,22 +47,7 @@ def main():
     parser = argparse.ArgumentParser()
     add_arguments(parser)
     args = parser.parse_args()
-
-    if args.log_config:
-        with open(args.log_config, 'r') as f:
-            logging.config.dictConfig(json.load(f))
-    elif args.log_file:
-        logging.basicConfig(filename=args.log_file, format=LOG_FORMAT)
-    else:
-        logging.basicConfig(format=LOG_FORMAT)
-
-    if args.verbose == 0:
-        level = logging.WARNING
-    elif args.verbose == 1:
-        level = logging.INFO
-    elif args.verbose >= 2:
-        level = logging.DEBUG
-    logging.getLogger().setLevel(level)
+    configure_logger(args)
 
     if args.tcp:
         language_server.start_tcp_lang_server(args.host, args.port, PythonLanguageServer)
@@ -95,3 +80,37 @@ def _binary_stdio():
         stdin, stdout = sys.stdin, sys.stdout
 
     return stdin, stdout
+
+def configure_logger(args):
+    log_config = args.log_config
+    root_logger = logging.root
+
+    if log_config:
+        with open(log_config, 'r') as f:
+            logging.config.dictConfig(json.load(f))
+    else:
+        log_file = args.log_file
+        formatter = logging.Formatter(LOG_FORMAT, style="%")
+        if log_file:
+            log_handler = logging.handlers.RotatingFileHandler(log_file, mode='a',
+                    maxBytes=50*1024*1024, backupCount=10, encoding=None, delay=0)
+        else:
+            log_handler = logging.StreamHandler()
+        log_handler.setFormatter(formatter)
+        root_logger.addHandler(log_handler)
+
+    # CRITICAL = 50
+    # FATAL = CRITICAL
+    # ERROR = 40
+    # WARNING = 30
+    # INFO = 20
+    # DEBUG = 10
+    if args.verbose == 0:
+        level = logging.WARNING
+    elif args.verbose == 1:
+        level = logging.INFO
+    elif args.verbose >= 2:
+        level = logging.DEBUG
+
+    root_logger.setLevel(level)
+


### PR DESCRIPTION
basicConfig: Do basic configuration for the logging system.
This function does nothing if the root logger already has handlers
configured. It is a convenience method intended for use by simple
scripts to do one-shot configuration of the logging package.