### PR TITLE
Fixes TypeError: '>=' not supported between instances of

### DIFF
--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -48,7 +48,7 @@ def main():
     parser = argparse.ArgumentParser()
     add_arguments(parser)
     args = parser.parse_args()
-    _configure_logger(args)
+    _configure_logger(args.verbose, args.log_config, args.log_file)
 
     if args.tcp:
         language_server.start_tcp_lang_server(args.host, args.port, PythonLanguageServer)


### PR DESCRIPTION
'Namespace' and 'int'

```
server: [pyls] 19:05:39:0782887 Logging to the file F:/SublimeText/debug.txt
server: Traceback (most recent call last):
server: File "F:\Python\Scripts\pyls-script.py", line 11, in <module>
server: load_entry_point('python-language-server', 'console_scripts', 'pyls')()
server: File "d:\user\dropbox\softwareversioning\python-language-server\pyls\__main__.py", line 55, in main
server: _configure_logger(args)
server: File "d:\user\dropbox\softwareversioning\python-language-server\pyls\__main__.py", line 112, in _configure_logger
server: elif verbose >= 2:
server: TypeError: '>=' not supported between instances of 'Namespace' and 'int'
```