### PR TITLE
Created the rope.create_folder setting to not create the

### DIFF
--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -70,8 +70,8 @@ class PythonLanguageServer(LanguageServer):
         return server_capabilities
 
     def initialize(self, root_uri, init_opts, _process_id):
-        self.workspace = Workspace(root_uri, lang_server=self)
         self.config = config.Config(root_uri, init_opts)
+        self.workspace = Workspace(root_uri, lang_server=self)
         self._dispatchers = self._hook('pyls_dispatchers')
         self._hook('pyls_initialize')
 

--- a/pyls/server.py
+++ b/pyls/server.py
@@ -56,8 +56,8 @@ class JSONRPCServer(object):
                         on_result(msg['result'])
                     elif 'error' in msg and on_error:
                         on_error(msg['error'])
-            except:  # pylint: disable=bare-except
-                log.exception("Language server exiting due to uncaught exception")
+            except Exception as error:
+                log.exception("Language server exiting due to uncaught exception: %" % error)
                 break
 
     def call(self, method, params=None, on_result=None, on_error=None):

--- a/pyls/server.py
+++ b/pyls/server.py
@@ -56,7 +56,7 @@ class JSONRPCServer(object):
                         on_result(msg['result'])
                     elif 'error' in msg and on_error:
                         on_error(msg['error'])
-            except Exception as error: # pylint: disable=broad-except
+            except Exception as error:  # pylint: disable=broad-except
                 log.exception("Language server exiting due to uncaught exception: %s", error)
                 break
 

--- a/pyls/server.py
+++ b/pyls/server.py
@@ -56,8 +56,8 @@ class JSONRPCServer(object):
                         on_result(msg['result'])
                     elif 'error' in msg and on_error:
                         on_error(msg['error'])
-            except Exception as error:
-                log.exception("Language server exiting due to uncaught exception: %" % error)
+            except Exception as error: # pylint: disable=broad-except
+                log.exception("Language server exiting due to uncaught exception: %s", error)
                 break
 
     def call(self, method, params=None, on_result=None, on_error=None):

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -9,7 +9,7 @@ import pkgutil
 
 import jedi
 from rope.base import libutils
-from rope.base.project import Project
+from rope.base.project import Project, get_no_project
 
 from . import lsp, uris, _utils
 
@@ -83,12 +83,17 @@ class Workspace(object):
 
         # Whilst incubating, keep private
         self.__rope = Project(self._root_path)
+
+        if self._lang_server.config.plugin_settings('rope').get('create_folder' ,True):
+            self.__rope = Project(self._root_path)
+        else:
+            self.__rope = get_no_project()
         self.__rope.prefs.set('extension_modules', self.PRELOADED_MODULES)
 
     @property
     def _rope(self):
         # TODO: we could keep track of dirty files and validate only those
-        self.__rope.validate()
+        self.__rope.validate(None)
         return self.__rope
 
     @property

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -74,7 +74,7 @@ class Workspace(object):
     M_SHOW_MESSAGE = 'window/showMessage'
     PRELOADED_MODULES = get_preferred_submodules()
 
-    def __init__(self, root_uri, lang_server=None):
+    def __init__(self, root_uri, lang_server):
         self._root_uri = root_uri
         self._root_uri_scheme = uris.urlparse(self._root_uri)[0]
         self._root_path = uris.to_fs_path(self._root_uri)

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -88,6 +88,9 @@ class Workspace(object):
             self.__rope = Project(self._root_path)
         else:
             self.__rope = get_no_project()
+            self.__rope.root = property(lambda self: self.get_resource(''))
+            self.__rope.address = property(lambda self: self._address)
+            self.__rope._get_resource_path = lambda self, name: os.path.join(self._address, *name.split('/'))
         self.__rope.prefs.set('extension_modules', self.PRELOADED_MODULES)
 
     @property

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -84,7 +84,7 @@ class Workspace(object):
         # Whilst incubating, keep private
         self.__rope = Project(self._root_path)
 
-        if self._lang_server.config.plugin_settings('rope').get('create_folder' ,True):
+        if self._lang_server.config.plugin_settings('rope').get('create_folder', True):
             self.__rope = Project(self._root_path)
         else:
             self.__rope = get_no_project()

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -9,7 +9,7 @@ import pkgutil
 
 import jedi
 from rope.base import libutils
-from rope.base.project import Project, get_no_project
+from rope.base.project import Project
 
 from . import lsp, uris, _utils
 
@@ -82,15 +82,10 @@ class Workspace(object):
         self._lang_server = lang_server
 
         # Whilst incubating, keep private
-        self.__rope = Project(self._root_path)
-
-        if self._lang_server.config.plugin_settings('rope').get('create_folder', True):
+        if self._lang_server.config.plugin_settings('rope').get('create_folder', False):
             self.__rope = Project(self._root_path)
         else:
-            self.__rope = get_no_project()
-            self.__rope.root = property(lambda self: self.get_resource(''))
-            self.__rope.address = property(lambda self: self._address)
-            self.__rope._get_resource_path = lambda self, name: os.path.join(self._address, *name.split('/'))
+            self.__rope = Project(self._root_path, ropefolder=None)
         self.__rope.prefs.set('extension_modules', self.PRELOADED_MODULES)
 
     @property

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -26,7 +26,7 @@ def pyls(tmpdir):
 @pytest.fixture
 def workspace(tmpdir):
     """Return a workspace."""
-    return Workspace(uris.from_fs_path(str(tmpdir)))
+    return Workspace(uris.from_fs_path(str(tmpdir)), pyls(tmpdir))
 
 
 @pytest.fixture


### PR DESCRIPTION
.ropeproject folder and config.py file. Related to:
1. https://github.com/python-rope/rope/issues/234 you can even tell rope not to create .ropeproject folder
1. https://github.com/palantir/python-language-server/issues/230 Maybe we should prevent creating a .ropeproject/config.py

The setting can be created just like the others:
```json
			"settings":
			{
				"pyls":
				{
					"plugins":
					{
						"pycodestyle":
						{
							"enabled": false
						},
						"rope":
						{
							"create_folder": false
						},
					}
				}
			},
```