### PR TITLE
Replaced RotatingFileHandler by ConcurrentRotatingFileHandler

### DIFF
--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -5,6 +5,8 @@ import logging
 import logging.config
 import sys
 
+from concurrent_log_handler import ConcurrentRotatingFileHandler
+
 from . import language_server
 from .python_ls import PythonLanguageServer
 
@@ -40,7 +42,7 @@ def add_arguments(parser):
 
     parser.add_argument(
         '-v', '--verbose', action='count', default=0,
-        help="Increase verbosity of log output, overrides log config file"
+        help="Increase verbosity of log output, overrides log config file."
     )
 
 
@@ -92,7 +94,7 @@ def _configure_logger(verbose=0, log_config=None, log_file=None):
     else:
         formatter = logging.Formatter(LOG_FORMAT)
         if log_file:
-            log_handler = logging.handlers.RotatingFileHandler(
+            log_handler = ConcurrentRotatingFileHandler(
                 log_file, mode='a', maxBytes=50*1024*1024,
                 backupCount=10, encoding=None, delay=0
             )

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     install_requires=[
         'configparser',
         'concurrent-log-handler',
+        'pypiwin32',
         'future>=0.14.0',
         'jedi>=0.10',
         'json-rpc',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'configparser',
+        'concurrent-log-handler',
         'future>=0.14.0',
         'jedi>=0.10',
         'json-rpc',


### PR DESCRIPTION
Replaced RotatingFileHandler by ConcurrentRotatingFileHandler
module concurrent-log-handler because when there are multiple pyls
server's running the file rotation fails.