### PR TITLE
strip line with \r\n before calculation of max column

### DIFF
--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -104,5 +104,5 @@ def format_docstring(contents):
 def clip_column(column, lines, line_number):
     # Normalise the position as per the LSP that accepts character positions > line length
     # https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#position
-    max_column = len(lines[line_number]) - 1 if len(lines) > line_number else 0
+    max_column = len(lines[line_number].strip('\r\n')) if len(lines) > line_number else 0
     return min(column, max_column)


### PR DESCRIPTION
When cursor is in the last line, at the end of the line and user requests for completions, column position is calculated incorrectly. It happens due to missing new line character. In this fix, line is stripped before calculation of its length and received value is taken as max_column.