### PR TITLE
Mark some pyflakes flakes as errors

### DIFF
--- a/pyls/plugins/pyflakes_lint.py
+++ b/pyls/plugins/pyflakes_lint.py
@@ -54,8 +54,10 @@ class PyflakesDiagnosticReport(object):
         }
 
         severity = lsp.DiagnosticSeverity.Warning
-        if type(message) in PYFLAKES_ERROR_MESSAGES:
-            severity = lsp.DiagnosticSeverity.Error
+        for message_type in PYFLAKES_ERROR_MESSAGES:
+            if isinstance(message, message_type):
+                severity = lsp.DiagnosticSeverity.Error
+                break
 
         self.diagnostics.append({
             'source': 'pyflakes',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'mccabe',
         'pycodestyle',
         'pydocstyle>=2.0.0',
-        'pyflakes',
+        'pyflakes>=1.6.0',
         'rope>=0.10.5',
         'yapf',
         'pluggy'

--- a/test/plugins/test_pyflakes_lint.py
+++ b/test/plugins/test_pyflakes_lint.py
@@ -1,5 +1,5 @@
 # Copyright 2017 Palantir Technologies, Inc.
-from pyls import uris
+from pyls import lsp, uris
 from pyls.workspace import Document
 from pyls.plugins import pyflakes_lint
 
@@ -16,6 +16,8 @@ DOC_SYNTAX_ERR = """def hello()
     pass
 """
 
+DOC_UNDEFINED_NAME_ERR = "a = b"
+
 
 def test_pyflakes():
     doc = Document(DOC_URI, DOC)
@@ -26,6 +28,7 @@ def test_pyflakes():
     unused_import = [d for d in diags if d['message'] == msg][0]
 
     assert unused_import['range']['start'] == {'line': 0, 'character': 0}
+    assert unused_import['severity'] == lsp.DiagnosticSeverity.Warning
 
 
 def test_syntax_error_pyflakes():
@@ -34,3 +37,13 @@ def test_syntax_error_pyflakes():
 
     assert diag['message'] == 'invalid syntax'
     assert diag['range']['start'] == {'line': 0, 'character': 12}
+    assert diag['severity'] == lsp.DiagnosticSeverity.Error
+
+
+def test_undefined_name_pyflakes():
+    doc = Document(DOC_URI, DOC_UNDEFINED_NAME_ERR)
+    diag = pyflakes_lint.pyls_lint(doc)[0]
+
+    assert diag['message'] == 'undefined name \'b\''
+    assert diag['range']['start'] == {'line': 0, 'character': 4}
+    assert diag['severity'] == lsp.DiagnosticSeverity.Error


### PR DESCRIPTION
Unfortunately, PyFlakes doesn't make this distinction. So we'll have to do it manually and keep it up-to-date as and when they introduce new flakes we consider errors and we want to take a higher dependency on pyflakes.

Fixes #235 