### PR TITLE
Make plugins optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ A Python 2.7 and 3.4+ implementation of the `Language Server Protocol`_.
 Installation
 ------------
 
-The base language server required Jedi_ to provide Completions, Definitions, Hover, References, Signature Help, and
+The base language server requires Jedi_ to provide Completions, Definitions, Hover, References, Signature Help, and
 Symbols:
 
 ``pip install python-language-server``

--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,16 @@ Python Language Server
 
 A Python 2.7 and 3.4+ implementation of the `Language Server Protocol`_.
 
-Feature Providers
------------------
-* Jedi_ for Completions, Definitions, Hover, References, Signature Help, and Symbols
+Installation
+------------
+
+The base language server required Jedi_ to provide Completions, Definitions, Hover, References, Signature Help, and
+Symbols:
+
+``pip install python-language-server``
+
+If the respective dependencies are found, the following optional providers will be enabled:
+
 * Rope_ for Completions and renaming
 * Pyflakes_ linter to detect various errors
 * McCabe_ linter for complexity checking
@@ -22,12 +29,23 @@ Feature Providers
 * pydocstyle_ linter for docstring style checking
 * YAPF_ for code formatting
 
+Optional providers can be installed using the `extras` syntax. To install YAPF_ formatting for example:
+
+``pip install 'python-language-server[yapf]'``
+
+All optional providers can be installed using:
+
+``pip install 'python-language-server[all]'``
+
 3rd Party Plugins
 ~~~~~~~~~~~~~~~~~
 Installing these plugins will add extra functionality to the language server:
 
 * pyls-mypy_ Mypy type checking for Python 3
 * pyls-isort_ Isort import sort code formatting
+
+Please see the above repositories for examples on how to write plugins for the Python Language Server. Please file an
+issue if you require assistance writing a plugin.
 
 Configuration
 -------------
@@ -77,11 +95,6 @@ Document Symbols:
 Document Formatting:
 
 .. image:: https://raw.githubusercontent.com/palantir/python-language-server/develop/resources/document-format.gif
-
-Installation
-------------
-
-``pip install python-language-server``
 
 Development
 -----------

--- a/pyls/config/config.py
+++ b/pyls/config/config.py
@@ -1,7 +1,6 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
 import pkg_resources
-import warnings
 
 import pluggy
 

--- a/pyls/config/config.py
+++ b/pyls/config/config.py
@@ -1,5 +1,8 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
+import pkg_resources
+import warnings
+
 import pluggy
 
 from pyls import _utils, hookspecs, uris, PYLS
@@ -32,10 +35,23 @@ class Config(object):
         self._pm.trace.root.setwriter(log.debug)
         self._pm.enable_tracing()
         self._pm.add_hookspecs(hookspecs)
+
+        # Pluggy will skip loading a plugin if it throws a DistributionNotFound exception.
+        # However I don't want all plugins to have to catch ImportError and re-throw. So here we'll filter
+        # out any entry points that throw ImportError assuming one or more of their dependencies isn't present.
+        for entry_point in pkg_resources.iter_entry_points(PYLS):
+            try:
+                entry_point.load()
+            except ImportError as e:
+                log.warn("Failed to load %s entry point '%s': %s", PYLS, entry_point.name, e)
+                self._pm.set_blocked(entry_point.name)
+
+        # Load the entry points into pluggy, having blocked any failing ones
         self._pm.load_setuptools_entrypoints(PYLS)
 
         for name, plugin in self._pm.list_name_plugin():
-            log.info("Loaded pyls plugin %s from %s", name, plugin)
+            if plugin is not None:
+                log.info("Loaded pyls plugin %s from %s", name, plugin)
 
         for plugin_conf in self._pm.hook.pyls_settings(config=self):
             self._plugin_settings = _utils.merge_dicts(self._plugin_settings, plugin_conf)

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -8,8 +8,6 @@ import imp
 import pkgutil
 
 import jedi
-from rope.base import libutils
-from rope.base.project import Project
 
 from . import lsp, uris, _utils
 
@@ -81,13 +79,18 @@ class Workspace(object):
         self._root_path = uris.to_fs_path(self._root_uri)
         self._docs = {}
 
-        # Whilst incubating, keep private
-        self.__rope = Project(self._root_path)
-        self.__rope.prefs.set('extension_modules', self.PRELOADED_MODULES)
+        # Whilst incubating, keep rope private
+        self.__rope = None
+        self.__rope_config = None
 
-    @property
-    def _rope(self):
+    def _rope_project_builder(self, rope_config):
+        from rope.base.project import Project
+
         # TODO: we could keep track of dirty files and validate only those
+        if self.__rope is None or self.__rope_config != rope_config:
+            rope_folder = rope_config.get('ropeFolder')
+            self.__rope = Project(self._root_path, ropefolder=rope_folder)
+            self.__rope.prefs.set('extension_modules', self.PRELOADED_MODULES)
         self.__rope.validate()
         return self.__rope
 
@@ -164,9 +167,9 @@ class Document(object):
     def __str__(self):
         return str(self.uri)
 
-    @property
-    def _rope(self):
-        return libutils.path_to_resource(self._rope_project, self.path)
+    def _rope_resource(self, rope_config):
+        from rope.base import libutils
+        return libutils.path_to_resource(self._rope_project_builder(rope_config), self.path)
 
     @property
     def lines(self):

--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,6 @@ setup(
         'futures; python_version<"3.2"',
         'jedi>=0.10',
         'json-rpc==1.10.8',
-        'mccabe',
-        'pycodestyle',
-        'pydocstyle>=2.0.0',
-        'pyflakes',
-        'rope>=0.10.5',
-        'yapf',
         'pluggy'
     ],
 
@@ -51,6 +45,12 @@ setup(
     # for example:
     # $ pip install -e .[test]
     extras_require={
+        'mccabe': ['mccabe'],
+        'pycodestyle': ['pycodestyle'],
+        'pydocstyle': ['pydocstyle>=2.0.0'],
+        'pyflakes': ['pyflakes'],
+        'rope': ['rope>0.10.5'],
+        'yapf': ['yapf'],
         'test': ['tox', 'versioneer', 'pytest', 'mock', 'pytest-cov', 'coverage'],
     },
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,14 @@ setup(
     # for example:
     # $ pip install -e .[test]
     extras_require={
+        'all': [
+            'mccabe',
+            'pycodestyle',
+            'pydocstyle>=2.0.0',
+            'pyflakes>=1.6.0',
+            'rope>-0.10.5',
+            'yapf',
+        ],
         'mccabe': ['mccabe'],
         'pycodestyle': ['pycodestyle'],
         'pydocstyle': ['pydocstyle>=2.0.0'],

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist = py27,py34,lint
-install_command = pip install .[all] {opts} {packages}
+install_command = pip install -e .[all] {opts} {packages}
 
 [pycodestyle]
 ignore = E226, E722

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@
 
 [tox]
 envlist = py27,py34,lint
-install_command = pip install -e .[all] {opts} {packages}
 
 [pycodestyle]
 ignore = E226, E722
@@ -27,6 +26,7 @@ deps =
     mock
     pytest-cov
     pylint
+extras = all
 
 [testenv:lint]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@
 
 [tox]
 envlist = py27,py34,lint
+install_command = pip install .[all] {opts} {packages}
 
 [pycodestyle]
 ignore = E226, E722


### PR DESCRIPTION
By ignoring ImportErrors when loading plugins, we can disable them whenever a dependency doesn't exist instead of PYLS having a large number of defined dependencies.

Fixes #299 