### PR TITLE
Catch Rope completions syntax errors

### DIFF
--- a/pyls/plugins/rope_completion.py
+++ b/pyls/plugins/rope_completion.py
@@ -30,7 +30,11 @@ def pyls_completions(config, workspace, document, position):
     rope_project = workspace._rope_project_builder(rope_config)
     document_rope = document._rope_resource(rope_config)
 
-    definitions = code_assist(rope_project, document.source, offset, document_rope, maxfixes=3)
+    try:
+        definitions = code_assist(rope_project, document.source, offset, document_rope, maxfixes=3)
+    except Exception as e:  # pylint: disable=broad-except
+        log.debug("Failed to run Rope code assist: %s", e)
+        return []
 
     definitions = sorted_proposals(definitions)
     new_definitions = []

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -91,6 +91,8 @@ class Workspace(object):
             rope_folder = rope_config.get('ropeFolder')
             self.__rope = Project(self._root_path, ropefolder=rope_folder)
             self.__rope.prefs.set('extension_modules', self.PRELOADED_MODULES)
+            self.__rope.prefs.set('ignore_syntax_errors', True)
+            self.__rope.prefs.set('ignore_bad_imports', True)
         self.__rope.validate()
         return self.__rope
 

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -40,6 +40,10 @@ def test_symbols(config):
     # Not going to get too in-depth here else we're just testing Jedi
     assert sym('a')['location']['range']['start'] == {'line': 2, 'character': 0}
 
+    # Ensure that the symbol range spans the whole definition
+    assert sym('main')['location']['range']['start'] == {'line': 9, 'character': 0}
+    assert sym('main')['location']['range']['end'] == {'line': 12, 'character': 0}
+
 
 def test_symbols_all_scopes(config):
     doc = Document(DOC_URI, DOC)


### PR DESCRIPTION
Rope cannot provide completions when the module has syntax errors :(

Best we can do is set Rope to try to ignore errors.

Similar to https://github.com/spyder-ide/spyder/issues/542

Fixes #209 
Fixes #284 