### PR TITLE
configparser is built-in in Python>=3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'configparser',
+        'configparser; python_version<"3.0"',
         'future>=0.14.0',
         'futures; python_version<"3.2"',
         'jedi>=0.10',


### PR DESCRIPTION
If I understand it correctly we need `configparser` only for <3.0 (2.7), because `configparser` is built-in for `>="3.0"` and we don't use it explicitly as a backport.

Quoting: https://pypi.python.org/pypi/configparser
> To use the configparser backport instead of the built-in version on both Python 2 and Python 3, simply import it explicitly as a backport: `from backports import configparser`
> If you’d like to use the backport on Python 2 and the built-in version on Python 3, use that invocation instead: `import configparser`

And the 2nd option `import configparser` is what is used in https://github.com/palantir/python-language-server/blob/develop/pyls/config/source.py, so how about making this dependency `python_version<"3.0"` only?

Additional NOTE for Conda users: `configparser` is available only for Python 2.7, so this dependency cannot be satisfied with Conda and Python 3.x.

~~~
> conda search configparser
Loading channels: done
# Name                  Version           Build  Channel
configparser            3.5.0b2          py27_1  pkgs/free
configparser              3.5.0          py27_0  pkgs/free
configparser              3.5.0  py27h2fa79a8_0  pkgs/main
~~~