### PR TITLE
rename now reports correct number of lines.

### DIFF
--- a/pyls/plugins/rope_rename.py
+++ b/pyls/plugins/rope_rename.py
@@ -1,9 +1,6 @@
 # Copyright 2017 Palantir Technologies, Inc.
-from functools import reduce
-import io
 import logging
 import os
-import sys
 
 from rope.base import libutils
 from rope.refactor.rename import Rename
@@ -11,13 +8,6 @@ from rope.refactor.rename import Rename
 from pyls import hookimpl, uris
 
 log = logging.getLogger(__name__)
-
-
-def _num_lines(resource):
-    """Count the number of lines in a `File` resource.
-    """
-    s = io.StringIO(resource.read())
-    return reduce(lambda x, _: x + 1, s, 0)
 
 
 @hookimpl
@@ -50,3 +40,8 @@ def pyls_rename(config, workspace, document, position, new_name):
             }]
         } for change in changeset.changes]
     }
+
+
+def _num_lines(resource):
+    "Count the number of lines in a `File` resource."
+    return len(resource.read().splitlines())

--- a/pyls/plugins/rope_rename.py
+++ b/pyls/plugins/rope_rename.py
@@ -1,4 +1,6 @@
 # Copyright 2017 Palantir Technologies, Inc.
+from functools import reduce
+import io
 import logging
 import os
 import sys
@@ -9,6 +11,13 @@ from rope.refactor.rename import Rename
 from pyls import hookimpl, uris
 
 log = logging.getLogger(__name__)
+
+
+def _num_lines(resource):
+    """Count the number of lines in a `File` resource.
+    """
+    s = io.StringIO(resource.read())
+    return reduce(lambda x, _: x + 1, s, 0)
 
 
 @hookimpl
@@ -35,7 +44,7 @@ def pyls_rename(config, workspace, document, position, new_name):
             'edits': [{
                 'range': {
                     'start': {'line': 0, 'character': 0},
-                    'end': {'line': sys.maxsize, 'character': 0},
+                    'end': {'line': _num_lines(change.resource), 'character': 0},
                 },
                 'newText': change.new_contents
             }]

--- a/pyls/plugins/rope_rename.py
+++ b/pyls/plugins/rope_rename.py
@@ -30,6 +30,7 @@ def pyls_rename(config, workspace, document, position, new_name):
                 'uri': uris.uri_with(
                     document.uri, path=os.path.join(workspace.root_path, change.resource.path)
                 ),
+                'version': document.version 
             },
             'edits': [{
                 'range': {

--- a/pyls/plugins/rope_rename.py
+++ b/pyls/plugins/rope_rename.py
@@ -30,7 +30,7 @@ def pyls_rename(config, workspace, document, position, new_name):
                 'uri': uris.uri_with(
                     document.uri, path=os.path.join(workspace.root_path, change.resource.path)
                 ),
-                'version': document.version 
+                'version': workspace.get_document(document.uri).version
             },
             'edits': [{
                 'range': {


### PR DESCRIPTION
It was initially reporting `sys.maxsize` all of the time, and this was both
incorrect and problematic for some clients.

See #218 for more information.