### PR TITLE
use difflib to generate TextEdits

### DIFF
--- a/pyls/plugins/yapf_format.py
+++ b/pyls/plugins/yapf_format.py
@@ -1,6 +1,11 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
 import os
+
+from bisect import bisect
+from difflib import SequenceMatcher
+from itertools import accumulate
+
 from yapf.yapflib import file_resources
 from yapf.yapflib.yapf_api import FormatCode
 from pyls import hookimpl
@@ -16,9 +21,7 @@ def pyls_format_document(document):
 @hookimpl
 def pyls_format_range(document, range):  # pylint: disable=redefined-builtin
     # First we 'round' the range up/down to full lines only
-    range['start']['character'] = 0
-    range['end']['line'] += 1
-    range['end']['character'] = 0
+    start, end = range['start']['line'], range['end']['line']
 
     # From Yapf docs:
     # lines: (list of tuples of integers) A list of tuples of lines, [start, end],
@@ -27,30 +30,32 @@ def pyls_format_range(document, range):  # pylint: disable=redefined-builtin
     #   than a whole file.
 
     # Add 1 for 1-indexing vs LSP's 0-indexing
-    lines = [(range['start']['line'] + 1, range['end']['line'] + 1)]
+    lines = ((start + 1), end + (start == end)),
     return _format(document, lines=lines)
 
 
 def _format(document, lines=None):
-    new_source, changed = FormatCode(
-        document.source,
+    src = document.source
+    updated, changed = FormatCode(
+        src,
         lines=lines,
         filename=document.filename,
         style_config=file_resources.GetDefaultStyleForDir(
             os.path.dirname(document.filename)
         )
     )
-
     if not changed:
         return []
-
-    # I'm too lazy at the moment to parse diffs into TextEdit items
-    # So let's just return the entire file...
-    return [{
-        'range': {
-            'start': {'line': 0, 'character': 0},
-            # End char 0 of the line after our document
-            'end': {'line': len(document.lines), 'character': 0}
-        },
-        'newText': new_source
-    }]
+    positions = [0] + list(accumulate(map(len, src.splitlines(keepends=True))))
+    def make_position(i):
+        pos = bisect(positions, i)
+        return dict(line=pos - 1, character=i - positions[pos - 1])
+    opcodes = SequenceMatcher(None, src, updated).get_opcodes()
+    return [
+        dict(
+            range=dict(start=make_position(i1), end=make_position(i2)),
+            newText=updated[j1:j2]
+        )
+        for tag, i1, i2, j1, j2 in opcodes
+        if tag != 'equal' or i1 != j1 or i2 != j2
+    ]


### PR DESCRIPTION
According to the language server specification `range.end` is exclusive, but neovim languge client seems to ignore that and when I try to format current line it sends the same line as start and end instead of `{"start": {"line": current_line, "character": 0}, "end": {"line": current_line + 1, "character": 0}}`. That's why I added

`end + (start == end)`