### PR TITLE
Added support for jedi to follow_imports on definitions

### DIFF
--- a/pyls/config/config.py
+++ b/pyls/config/config.py
@@ -9,7 +9,7 @@ from pyls import _utils, hookspecs, uris, PYLS
 log = logging.getLogger(__name__)
 
 # Sources of config, first source overrides next source
-DEFAULT_CONFIG_SOURCES = ['pycodestyle']
+DEFAULT_CONFIG_SOURCES = ['pycodestyle', 'jedi']
 
 
 class Config(object):
@@ -31,6 +31,11 @@ class Config(object):
         try:
             from .pycodestyle_conf import PyCodeStyleConfig
             self._config_sources['pycodestyle'] = PyCodeStyleConfig(self._root_path)
+        except ImportError:
+            pass
+        try:
+            from .jedi_conf import JediConfig
+            self._config_sources['jedi'] = JediConfig(self._root_path)
         except ImportError:
             pass
 

--- a/pyls/config/jedi_conf.py
+++ b/pyls/config/jedi_conf.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
+import os
 from pyls._utils import find_parents
 from .source import ConfigSource
-import os
 
 CONFIG_KEY = 'jedi'
 PROJECT_CONFIGS = ['.jedi']

--- a/pyls/config/jedi_conf.py
+++ b/pyls/config/jedi_conf.py
@@ -1,0 +1,28 @@
+# Copyright 2017 Palantir Technologies, Inc.
+from pyls._utils import find_parents
+from .source import ConfigSource
+import os
+
+CONFIG_KEY = 'jedi'
+PROJECT_CONFIGS = ['.jedi']
+
+OPTIONS = [
+    ('follow_imports', 'plugins.jedi.follow_imports', bool)
+]
+
+
+class JediConfig(ConfigSource):
+
+    def user_config(self):
+        config = self.read_config_from_files([self._user_config_file()])
+        return self.parse_config(config, CONFIG_KEY, OPTIONS)
+
+    def _user_config_file(self):
+        if self.is_windows:
+            return os.path.expanduser('~\\.{}'.format(CONFIG_KEY))
+        return os.path.join(self.xdg_home, CONFIG_KEY)
+
+    def project_config(self, document_path):
+        files = find_parents(self.root_path, document_path, PROJECT_CONFIGS)
+        config = self.read_config_from_files(files)
+        return self.parse_config(config, CONFIG_KEY, OPTIONS)

--- a/pyls/config/source.py
+++ b/pyls/config/source.py
@@ -64,7 +64,7 @@ def _get_opt(config, key, option, opt_type):
             continue
 
         if opt_type == bool:
-            return config.getbool(key, opt_key)
+            return config.getboolean(key, opt_key)
 
         if opt_type == int:
             return config.getint(key, opt_key)

--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -6,8 +6,9 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl
-def pyls_definitions(document, position):
-    definitions = document.jedi_script(position).goto_assignments()
+def pyls_definitions(document, position, config):
+    follow_imports = config.settings().get('plugins').get('jedi', {}).get('follow_imports', False)
+    definitions = document.jedi_script(position).goto_assignments(follow_imports=follow_imports)
 
     definitions = [
         d for d in definitions

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -19,7 +19,7 @@ class Directory(object):
 """
 
 
-def test_definitions():
+def test_definitions(config):
     # Over 'a' in print a
     cursor_pos = {'line': 3, 'character': 6}
 
@@ -30,19 +30,19 @@ def test_definitions():
     }
 
     doc = Document(DOC_URI, DOC)
-    assert [{'uri': DOC_URI, 'range': def_range}] == pyls_definitions(doc, cursor_pos)
+    assert [{'uri': DOC_URI, 'range': def_range}] == pyls_definitions(doc, cursor_pos, config)
 
 
-def test_builtin_definition():
+def test_builtin_definition(config):
     # Over 'i' in dict
     cursor_pos = {'line': 8, 'character': 24}
 
     # No go-to def for builtins
     doc = Document(DOC_URI, DOC)
-    assert [] == pyls_definitions(doc, cursor_pos)
+    assert [] == pyls_definitions(doc, cursor_pos, config)
 
 
-def test_assignment():
+def test_assignment(config):
     # Over 's' in self.members[id]
     cursor_pos = {'line': 11, 'character': 19}
 
@@ -53,4 +53,4 @@ def test_assignment():
     }
 
     doc = Document(DOC_URI, DOC)
-    assert [{'uri': DOC_URI, 'range': def_range}] == pyls_definitions(doc, cursor_pos)
+    assert [{'uri': DOC_URI, 'range': def_range}] == pyls_definitions(doc, cursor_pos, config)

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -65,6 +65,11 @@
                     "default": true,
                     "description": "If True lists the names of all scopes instead of only the module namespace."
                 },
+                "plugins.jedi.follow_imports": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If True follow jedi definitions recursively as far as possible."
+                },
                 "pyls.plugins.mccabe.enabled": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
Hi, 

Currently, the `pyls_definitions` is calling the `goto_assignments` of the jedi package, and I was missing the feature of follow_imports on this `goto_assignments` method, which follows the definition as far as possible recursively. So, I'd like to expose this follow_imports variable to the users, could you please allow us to have this variable in the settings? By default, in order not to change the behavior I left this argument as False. I'd appreciate further guidance to get this PR merged.  

I've tested with this jedi configuration file `~/.config/jedi`:
```
[jedi]
follow_imports = True
```