### PR TITLE
Do not hide unexpected errors from pyflakes

### DIFF
--- a/pyls/plugins/pyflakes_lint.py
+++ b/pyls/plugins/pyflakes_lint.py
@@ -32,7 +32,16 @@ class PyflakesDiagnosticReport(object):
         self.diagnostics = []
 
     def unexpectedError(self, filename, msg):  # pragma: no cover
-        pass
+        err_range = {
+            'start': {'line': 0, 'character': 0},
+            'end': {'line': 0, 'character': 0},
+        }
+        self.diagnostics.append({
+            'source': 'pyflakes',
+            'range': err_range,
+            'message': msg,
+            'severity': lsp.DiagnosticSeverity.Error,
+        })
 
     def syntaxError(self, _filename, msg, lineno, offset, text):
         # We've seen that lineno and offset can sometimes be None

--- a/pyls/plugins/pyflakes_lint.py
+++ b/pyls/plugins/pyflakes_lint.py
@@ -31,7 +31,7 @@ class PyflakesDiagnosticReport(object):
         self.lines = lines
         self.diagnostics = []
 
-    def unexpectedError(self, filename, msg):  # pragma: no cover
+    def unexpectedError(self, _filename, msg):  # pragma: no cover
         err_range = {
             'start': {'line': 0, 'character': 0},
             'end': {'line': 0, 'character': 0},


### PR DESCRIPTION
Pyflake's api can report source decoding error throught unexpectedError. If these errors are hidden then it's hard to say if linter is enabled and working.