### PR TITLE
Don't pass unicode to pyflakes

### DIFF
--- a/pyls/plugins/pyflakes_lint.py
+++ b/pyls/plugins/pyflakes_lint.py
@@ -21,7 +21,7 @@ PYFLAKES_ERROR_MESSAGES = (
 @hookimpl
 def pyls_lint(document):
     reporter = PyflakesDiagnosticReport(document.lines)
-    pyflakes_api.check(document.source, document.path, reporter=reporter)
+    pyflakes_api.check(document.source.encode('utf-8'), document.path, reporter=reporter)
     return reporter.diagnostics
 
 

--- a/test/plugins/test_pyflakes_lint.py
+++ b/test/plugins/test_pyflakes_lint.py
@@ -19,6 +19,11 @@ DOC_SYNTAX_ERR = """def hello()
 DOC_UNDEFINED_NAME_ERR = "a = b"
 
 
+DOC_ENCODING = """# encoding=utf-8
+import sys
+""".decode('utf-8')
+
+
 def test_pyflakes():
     doc = Document(DOC_URI, DOC)
     diags = pyflakes_lint.pyls_lint(doc)
@@ -47,3 +52,11 @@ def test_undefined_name_pyflakes():
     assert diag['message'] == 'undefined name \'b\''
     assert diag['range']['start'] == {'line': 0, 'character': 4}
     assert diag['severity'] == lsp.DiagnosticSeverity.Error
+
+
+def test_unicode_encoding():
+    doc = Document(DOC_URI, DOC_ENCODING)
+    diags = pyflakes_lint.pyls_lint(doc)
+
+    assert len(diags) == 1
+    assert diags[0]['message'] == '\'sys\' imported but unused'

--- a/test/plugins/test_pyflakes_lint.py
+++ b/test/plugins/test_pyflakes_lint.py
@@ -19,9 +19,9 @@ DOC_SYNTAX_ERR = """def hello()
 DOC_UNDEFINED_NAME_ERR = "a = b"
 
 
-DOC_ENCODING = """# encoding=utf-8
+DOC_ENCODING = u"""# encoding=utf-8
 import sys
-""".decode('utf-8')
+"""
 
 
 def test_pyflakes():


### PR DESCRIPTION
pyflakes loads source code like this
```python
compile(code, filename, 'exec')
```

Since document source always returns unicode (https://github.com/palantir/python-language-server/pull/322) there are problem to lint files with encoding specified:
```python
Python 2.7.15
>>> compile(u'# encoding=utf-8', 'file_name.py', 'exec')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "file_name.py", line 0
SyntaxError: encoding declaration in Unicode string
```

Encoding source code back before passing it to pyflakes solves the broblem.