### PR TITLE
highlight should return an empty list instead of None

### DIFF
--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -187,7 +187,7 @@ class PythonLanguageServer(MethodDispatcher):
         return self._hook('pyls_format_range', doc_uri, range=range)
 
     def highlight(self, doc_uri, position):
-        return flatten(self._hook('pyls_document_highlight', doc_uri, position=position)) or None
+        return flatten(self._hook('pyls_document_highlight', doc_uri, position=position))
 
     def hover(self, doc_uri, position):
         return self._hook('pyls_hover', doc_uri, position=position) or {'contents': ''}


### PR DESCRIPTION
`pyls_document_highlight` would return an empty list when no usages found.

It is unnecessary that changing `[] or None` to `None`, just return `[]` instead.

This would be more compatible for various kinds of language clients.