### PR TITLE
Add pyls-black to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Installing these plugins will add extra functionality to the language server:
 
 * pyls-mypy_ Mypy type checking for Python 3
 * pyls-isort_ Isort import sort code formatting
+* pyls-black_ for code formatting using Black_
 
 Please see the above repositories for examples on how to write plugins for the Python Language Server. Please file an
 issue if you require assistance writing a plugin.
@@ -152,3 +153,5 @@ This project is made available under the MIT License.
 .. _autopep8: https://github.com/hhatto/autopep8
 .. _pyls-mypy: https://github.com/tomv564/pyls-mypy
 .. _pyls-isort: https://github.com/paradoxxxzero/pyls-isort
+.. _pyls-black: https://github.com/rupert/pyls-black
+.. _Black: https://github.com/ambv/black


### PR DESCRIPTION
Hi, thanks for the great project!

I recently wrote a [plugin](https://github.com/rupert/pyls-black) for the [Black](https://github.com/ambv/black) code formatter and was hoping it could be added to the `README` in case other people might find it useful.