### PR TITLE
Fix dev setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ The Python language server can be developed against a local instance of Visual S
 
     # Install the vscode-client extension
     cd vscode-client
-    yarn install .
+    yarn install
 
     # Run VSCode which is configured to use pyls
     # See the bottom of vscode-client/src/extension.ts for info


### PR DESCRIPTION
Fixes #388 

The dev setup was incorrect since it did not describe how to properly use `yarn install`.