### PR TITLE
Add Lint Trigger

### DIFF
--- a/pyls/hookspecs.py
+++ b/pyls/hookspecs.py
@@ -88,7 +88,7 @@ def pyls_initialize(config, workspace):
 
 
 @hookspec
-def pyls_lint(config, workspace, document):
+def pyls_lint(config, workspace, document, trigger):
     pass
 
 

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -194,10 +194,10 @@ class PythonLanguageServer(MethodDispatcher):
         return self._hook('pyls_hover', doc_uri, position=position) or {'contents': ''}
 
     @_utils.debounce(LINT_DEBOUNCE_S, keyed_by='doc_uri')
-    def lint(self, doc_uri):
+    def lint(self, doc_uri, trigger):
         # Since we're debounced, the document may no longer be open
         if doc_uri in self.workspace.documents:
-            self.workspace.publish_diagnostics(doc_uri, flatten(self._hook('pyls_lint', doc_uri)))
+            self.workspace.publish_diagnostics(doc_uri, flatten(self._hook('pyls_lint', doc_uri, trigger=trigger)))
 
     def references(self, doc_uri, position, exclude_declaration):
         return flatten(self._hook(
@@ -217,7 +217,7 @@ class PythonLanguageServer(MethodDispatcher):
     def m_text_document__did_open(self, textDocument=None, **_kwargs):
         self.workspace.put_document(textDocument['uri'], textDocument['text'], version=textDocument.get('version'))
         self._hook('pyls_document_did_open', textDocument['uri'])
-        self.lint(textDocument['uri'])
+        self.lint(textDocument['uri'], trigger='open')
 
     def m_text_document__did_change(self, contentChanges=None, textDocument=None, **_kwargs):
         for change in contentChanges:
@@ -226,10 +226,10 @@ class PythonLanguageServer(MethodDispatcher):
                 change,
                 version=textDocument.get('version')
             )
-        self.lint(textDocument['uri'])
+        self.lint(textDocument['uri'], trigger='change')
 
     def m_text_document__did_save(self, textDocument=None, **_kwargs):
-        self.lint(textDocument['uri'])
+        self.lint(textDocument['uri'], trigger='save')
 
     def m_text_document__code_action(self, textDocument=None, range=None, context=None, **_kwargs):
         return self.code_actions(textDocument['uri'], range, context)
@@ -273,12 +273,12 @@ class PythonLanguageServer(MethodDispatcher):
     def m_workspace__did_change_configuration(self, settings=None):
         self.config.update((settings or {}).get('pyls', {}))
         for doc_uri in self.workspace.documents:
-            self.lint(doc_uri)
+            self.lint(doc_uri, trigger='change-configuration')
 
     def m_workspace__did_change_watched_files(self, **_kwargs):
         # Externally changed files may result in changed diagnostics
         for doc_uri in self.workspace.documents:
-            self.lint(doc_uri)
+            self.lint(doc_uri, trigger='change-watched-files')
 
     def m_workspace__execute_command(self, command=None, arguments=None):
         return self.execute_command(command, arguments)


### PR DESCRIPTION
Pass a "trigger" string to the `pyls_lint` hook.  This allows linter
hook implementations to decide whether to run or not, based on what
triggered linting.  Useful for linters that are expensive to run,
so we don't want to run them on-change.

Since hook arguments are passed by keyword, this requires no changes
to existing local linter hook implementations.