### PR TITLE
Allow to use custom python interpreter [fixes #339]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'configparser; python_version<"3.0"',
         'future>=0.14.0',
         'futures; python_version<"3.2"',
-        'jedi>=0.12',
+        'jedi>=0.13',
         'python-jsonrpc-server>=0.1.0',
         'pluggy'
     ],


### PR DESCRIPTION
Python interpreter or virtualenv can be specified in settings. Server can receive them from `workspace/didChangeConfiguration` request.

Tested with SublimeText 3 and [LSP](https://github.com/tomv564/LSP) client plugin.
Example of Sublime LSP plugin settings:
```json
{
  "clients": {
    "pyls":
    {
      "command": ["pyls"],
      "settings":
      {
          "pyls":
          {
              "python_virtualenv": "/path/to/virtualenv/",
              "python_interpreter": "/path/to/virtualenv/bin/python",
          }
      },
      ...
    }
  }
}
```

Example of Sublime Text 3 project settings (to specify virtualenv specific to current project):
```json
// Project settings
{
    "folders":
    [

        {
            "path": "/path/to/my/project"
        }
    ],
    "settings":
    {
        "LSP":
        {
            "pyls":
            {
                "settings":
                {
                    "pyls":
                    {
                        "python_virtualenv": "/path/to/virtualenv/",
                        "python_interpreter": "/path/to/virtualenv/bin/python"
                    }
                }
            }
        }
    }
}
```