### PR TITLE
Respect option `follow_imports` in `goto_assignments` call

### DIFF
--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -7,8 +7,7 @@ log = logging.getLogger(__name__)
 
 @hookimpl
 def pyls_definitions(config, document, position):
-    expected_settings = {'follow_imports', 'follow_builtin_imports'}
-    params = {k: v for k, v in config.settings().items() if k in expected_settings}
+    params = {k: v for k, v in config.plugin_settings('jedi_definition').items() if k}
     definitions = document.jedi_script(position).goto_assignments(**params)
 
     definitions = [

--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 
 @hookimpl
 def pyls_definitions(config, document, position):
-    params = {k: v for k, v in config.plugin_settings('jedi_definition').items() if k}
+    params = {k: v for k, v in config.plugin_settings('jedi_definition').items() if v is not None}
     definitions = document.jedi_script(position).goto_assignments(**params)
 
     definitions = [

--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -6,8 +6,10 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl
-def pyls_definitions(document, position):
-    definitions = document.jedi_script(position).goto_assignments()
+def pyls_definitions(config, document, position):
+    expected_settings = {'follow_imports', 'follow_builtin_imports'}
+    params = {k: v for k, v in config.settings().items() if k in expected_settings}
+    definitions = document.jedi_script(position).goto_assignments(**params)
 
     definitions = [
         d for d in definitions

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -19,7 +19,7 @@ class Directory(object):
 """
 
 
-def test_definitions():
+def test_definitions(config):
     # Over 'a' in print a
     cursor_pos = {'line': 3, 'character': 6}
 
@@ -30,19 +30,19 @@ def test_definitions():
     }
 
     doc = Document(DOC_URI, DOC)
-    assert [{'uri': DOC_URI, 'range': def_range}] == pyls_definitions(doc, cursor_pos)
+    assert [{'uri': DOC_URI, 'range': def_range}] == pyls_definitions(config, doc, cursor_pos)
 
 
-def test_builtin_definition():
+def test_builtin_definition(config):
     # Over 'i' in dict
     cursor_pos = {'line': 8, 'character': 24}
 
     # No go-to def for builtins
     doc = Document(DOC_URI, DOC)
-    assert [] == pyls_definitions(doc, cursor_pos)
+    assert [] == pyls_definitions(config, doc, cursor_pos)
 
 
-def test_assignment():
+def test_assignment(config):
     # Over 's' in self.members[id]
     cursor_pos = {'line': 11, 'character': 19}
 
@@ -53,4 +53,4 @@ def test_assignment():
     }
 
     doc = Document(DOC_URI, DOC)
-    assert [{'uri': DOC_URI, 'range': def_range}] == pyls_definitions(doc, cursor_pos)
+    assert [{'uri': DOC_URI, 'range': def_range}] == pyls_definitions(config, doc, cursor_pos)

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -40,6 +40,16 @@
                     "default": true,
                     "description": "Enable or disable the plugin."
                 },
+                "pyls.plugins.jedi_definition.follow_imports": {
+                    "type": "boolean",
+                    "default": null,
+                    "description": "The goto call will follow imports."
+                },
+                "pyls.plugins.jedi_definition.follow_builtin_imports": {
+                    "type": "boolean",
+                    "default": null,
+                    "description": "If follow_imports is True will decide if it follow builtin imports."
+                },
                 "pyls.plugins.jedi_hover.enabled": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
Add an ability to specify `follow_imports`, `follow_builtin_imports` options in `goto_assignments` call: https://jedi.readthedocs.io/en/latest/docs/api.html#jedi.Script.goto_assignments