### PR TITLE
Fix goto_assignments config

### DIFF
--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 
 @hookimpl
 def pyls_definitions(config, document, position):
-    params = {k: v for k, v in config.plugin_settings('jedi_definition').items() if v is not None}
+    params = {k: v for k, v in config.plugin_settings('jedi_definition').items() if v is not None and k != 'enabled'}
     definitions = document.jedi_script(position).goto_assignments(**params)
 
     definitions = [

--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -7,8 +7,10 @@ log = logging.getLogger(__name__)
 
 @hookimpl
 def pyls_definitions(config, document, position):
-    params = {k: v for k, v in config.plugin_settings('jedi_definition').items() if v is not None and k != 'enabled'}
-    definitions = document.jedi_script(position).goto_assignments(**params)
+    settings = config.plugin_settings('jedi_definition')
+    definitions = document.jedi_script(position).goto_assignments(
+        follow_imports=settings.get('follow_imports', False),
+        follow_builtin_imports=settings.get('follow_builtin_imports', False))
 
     definitions = [
         d for d in definitions


### PR DESCRIPTION
This PR explicitly retrieves `jedi.goto_assignments` parameters from the config.

This fixes a bug introduced in #404 where the `enabled` config argument was passed to `jedi` and would fail with `TypeError: goto_assignments() got an unexpected keyword argument 'enabled'` otherwise.