### PR TITLE
Catch IndexError in pyls_signature_help

### DIFF
--- a/pyls/plugins/signature.py
+++ b/pyls/plugins/signature.py
@@ -20,10 +20,16 @@ def pyls_signature_help(document, position):
         return {'signatures': []}
 
     s = signatures[0]
-    sig = {
-        'label': s.docstring().splitlines()[0],
-        'documentation': _utils.format_docstring(s.docstring(raw=True))
-    }
+    try:
+        sig = {
+            'label': s.docstring().splitlines()[0],
+            'documentation': _utils.format_docstring(s.docstring(raw=True))
+        }
+    except IndexError:
+        sig = {
+            'label': s.docstring().splitlines(),
+            'documentation': _utils.format_docstring(s.docstring(raw=True))
+        }
 
     # If there are params, add those
     if s.params:


### PR DESCRIPTION
Fixes #459

This is how I'm addressing the issue locally, and it appears to fix the issue and causes the signature help to work correctly in coc.nvim.