### PR TITLE
Don't crash on completion, if class has @property

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -20,9 +20,17 @@ def pyls_completions(document, position):
 
 def _label(definition):
     if definition.type in ('function', 'method'):
-        params = ', '.join(param.name for param in definition.params)
-        return '{}({})'.format(definition.name, params)
-
+        try:
+            params = definition.params
+        except AttributeError as e:
+            # Probably function decorated with @property, no params for it
+            log.warning(
+                'Got AttributeError when trying to get params of %s: %s',
+                definition.full_name, e
+            )
+        else:
+            params_names = ', '.join(param.name for param in params)
+            return '{}({})'.format(definition.name, params_names)
     return definition.name
 
 


### PR DESCRIPTION
Example of code:

```python
class Notification(object):

    def send(self, text):
        return 'Sending {0} to {1}'.format(text, self.email)

    @property
    def email(self):
        return 'some@email.com'


notification = Notification()
notification.  # <-- expect to see `send` and `email` as possible attributes in completion
```

On last line, when pyls trying to find completions for `Notification` class, jedi raise [AttributeError](https://github.com/davidhalter/jedi/blob/master/jedi/api/classes.py#L314) on `definition.params` access.
The reason is that class has `@property`. And such property can't have any params. As a result, if class has any `@property`, auto-completion doesn't work.

This patch tends to fix it.