### PR TITLE
Reduce redundant lint calls

### DIFF
--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -294,10 +294,15 @@ class PythonLanguageServer(MethodDispatcher):
         for doc_uri in self.workspace.documents:
             self.lint(doc_uri)
 
-    def m_workspace__did_change_watched_files(self, **_kwargs):
-        # Externally changed files may result in changed diagnostics
+    def m_workspace__did_change_watched_files(self, changes=None, **_kwargs):
+        changed_py_files = set(d['uri'] for d in changes if d['uri'].endswith(('.py', '.pyi')))
+        # Only externally changed python files may result in changed diagnostics
+        if not changed_py_files:
+            return
         for doc_uri in self.workspace.documents:
-            self.lint(doc_uri)
+            # Changes in doc_uri are already handled by m_text_document__did_save
+            if doc_uri not in changed_py_files:
+                self.lint(doc_uri)
 
     def m_workspace__execute_command(self, command=None, arguments=None):
         return self.execute_command(command, arguments)


### PR DESCRIPTION
Currently, whenever a file in the workspace changes all open documents are linted. This causes a lot of unnecessary lint calls.
With this PR `pyls` ignores changes to files that do not end with `.py` or `.pyi` and changes that are already handled by the didChange event.

This issue is very problematic when using [`pyls-mypy`](https://github.com/tomv564/pyls-mypy/). `mypy` writes cache files after each lint which results in `didChangeWatchedFiles` to be triggered, resulting in a infinite lint loop.