### PR TITLE
Cache settings with lru_cache

### DIFF
--- a/pyls/config/config.py
+++ b/pyls/config/config.py
@@ -1,6 +1,10 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
 import pkg_resources
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 
 import pluggy
 
@@ -47,7 +51,7 @@ class Config(object):
             try:
                 entry_point.load()
             except ImportError as e:
-                log.warn("Failed to load %s entry point '%s': %s", PYLS, entry_point.name, e)
+                log.warning("Failed to load %s entry point '%s': %s", PYLS, entry_point.name, e)
                 self._pm.set_blocked(entry_point.name)
 
         # Load the entry points into pluggy, having blocked any failing ones
@@ -82,6 +86,7 @@ class Config(object):
     def process_id(self):
         return self._process_id
 
+    @lru_cache(maxsize=32)
     def settings(self, document_path=None):
         """Settings are constructed from a few sources:
 
@@ -90,7 +95,8 @@ class Config(object):
             3. LSP settings, given to us from didChangeConfiguration
             4. Project settings, found in config files in the current project.
 
-        TODO(gatesn): We should update a cached view of this whenever any configs change
+        Since this function is nondeterministic, it is important to call
+        settings.cache_clear() when the config is updated
         """
         settings = {}
         sources = self._settings.get('configurationSources', DEFAULT_CONFIG_SOURCES)
@@ -130,6 +136,7 @@ class Config(object):
 
     def update(self, settings):
         """Recursively merge the given settings into the current settings."""
+        self.settings.cache_clear()
         self._settings = settings
         log.info("Updated settings to %s", self._settings)
         self._update_disabled_plugins()

--- a/pyls/config/source.py
+++ b/pyls/config/source.py
@@ -17,9 +17,6 @@ class ConfigSource(object):
             'XDG_CONFIG_HOME', os.path.expanduser('~/.config')
         )
 
-        self._modified_times = {}
-        self._configs_cache = {}
-
     def user_config(self):
         """Return user-level (i.e. home directory) configuration."""
         raise NotImplementedError()
@@ -29,20 +26,10 @@ class ConfigSource(object):
         raise NotImplementedError()
 
     def read_config_from_files(self, files):
-        files = tuple([f for f in files if os.path.exists(f) and not os.path.isdir(f)])
-        modified = tuple([os.path.getmtime(f) for f in files])
-
-        if files in self._modified_times and modified == self._modified_times[files]:
-            log.debug("Using cached configuration for %s", files)
-            return self._configs_cache[files]
-
         config = configparser.RawConfigParser()
-        found_files = []
         for filename in files:
-            found_files.extend(config.read(filename))
-
-        self._configs_cache[files] = config
-        self._modified_times[files] = modified
+            if os.path.exists(filename) and not os.path.isdir(filename):
+                config.read(filename)
 
         return config
 

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -17,8 +17,8 @@ log = logging.getLogger(__name__)
 LINT_DEBOUNCE_S = 0.5  # 500 ms
 PARENT_PROCESS_WATCH_INTERVAL = 10  # 10 s
 MAX_WORKERS = 64
-# We also watch for changes in config files
-PYTHON_FILE_EXTENSIONS = ('.py', '.pyi', 'pycodestyle.cfg', 'setup.cfg', 'tox.ini', '.flake8')
+PYTHON_FILE_EXTENSIONS = ('.py', '.pyi')
+CONFIG_FILEs = ('pycodestyle.cfg', 'setup.cfg', 'tox.ini', '.flake8')
 
 
 class _StreamHandlerWrapper(socketserver.StreamRequestHandler, object):
@@ -296,13 +296,21 @@ class PythonLanguageServer(MethodDispatcher):
         for doc_uri in self.workspace.documents:
             self.lint(doc_uri)
 
-    def m_workspace__did_change_watched_files(self, changes=None, **_kwargs):
-        changed_py_files = set(d['uri'] for d in changes if d['uri'].endswith(PYTHON_FILE_EXTENSIONS))
-        # Only externally changed python files and lint configs may result in changed diagnostics.
-        if not changed_py_files:
+    def m_workspace__did_change_watched_files(self, changes=[], **_kwargs):
+        changed_py_files = set()
+        config_changed = False
+        for d in changes:
+            if d['uri'].endswith(PYTHON_FILE_EXTENSIONS):
+                changed_py_files.add(d['uri'])
+            elif d['uri'].endswith(CONFIG_FILEs):
+                config_changed = True
+
+        if config_changed:
+            self.settings.cache_clear()
+        elif not changed_py_files:
+            # Only externally changed python files and lint configs may result in changed diagnostics.
             return
-        # TODO: We currently don't cache settings therefor we can just lint again.
-        # Here would be the right point to update the settings after a change to config files.
+
         for doc_uri in self.workspace.documents:
             # Changes in doc_uri are already handled by m_text_document__did_save
             if doc_uri not in changed_py_files:

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'configparser; python_version<"3.0"',
         'future>=0.14.0',
         'futures; python_version<"3.2"',
+        'backports.functools_lru_cache; python_version<"3.2"',
         'jedi>=0.13.2',
         'python-jsonrpc-server>=0.1.0',
         'pluggy'

--- a/test/plugins/test_pycodestyle_lint.py
+++ b/test/plugins/test_pycodestyle_lint.py
@@ -82,6 +82,7 @@ def test_pycodestyle_config(workspace):
         # Now we'll add config file to ignore it
         with open(os.path.join(workspace.root_path, conf_file), 'w+') as f:
             f.write(content)
+        config.settings.cache_clear()
 
         # And make sure we don't get any warnings
         diags = pycodestyle_lint.pyls_lint(config, doc)


### PR DESCRIPTION
`Config.settings()` takes a few milliseconds to run and reads config files from disk. This function runs multiple times during initialization and before every linting request. This means we can very effectively cache the results.

This PR uses `lru_cache` to cache the the result of `Config.settings()`. The cache is invalidated when the config is updated or a config file is changed.

Fixes #305