### PR TITLE
Complete follow_imports defaults change

### DIFF
--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -9,8 +9,8 @@ log = logging.getLogger(__name__)
 def pyls_definitions(config, document, position):
     settings = config.plugin_settings('jedi_definition')
     definitions = document.jedi_script(position).goto_assignments(
-        follow_imports=settings.get('follow_imports', False),
-        follow_builtin_imports=settings.get('follow_builtin_imports', False))
+        follow_imports=settings.get('follow_imports', True),
+        follow_builtin_imports=settings.get('follow_builtin_imports', True))
 
     definitions = [
         d for d in definitions


### PR DESCRIPTION
Hi, first time here :)
Huge thanks for all the hard work, really appreciate it!

As far as I understand, the change in https://github.com/palantir/python-language-server/pull/483 is partial, as it only changes the defaults for the VS-Code plugin, and doesn't change for any other LSP-client.
(I'm using Oni, which is based on Neovim)

I think that this PR completes the change.