### PR TITLE
removed config.getbool in favor of the more-supported .getboolean

### DIFF
--- a/pyls/config/source.py
+++ b/pyls/config/source.py
@@ -64,7 +64,7 @@ def _get_opt(config, key, option, opt_type):
             continue
 
         if opt_type == bool:
-            return config.getbool(key, opt_key)
+            return config.getboolean(key, opt_key)
 
         if opt_type == int:
             return config.getint(key, opt_key)


### PR DESCRIPTION
today, `pyls` decided `RawConfigParser.getbool` wouldn't work with my setup.cfg. 
Looks like `.getboolean` does the same thing and is present in python 3, so I'm suggesting adopting it. 