### PR TITLE
Introduce hierarchical documentSymbol support

### DIFF
--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -8,7 +8,11 @@ log = logging.getLogger(__name__)
 
 @hookimpl
 def pyls_document_symbols(config, document):
-    if not config.capabilities.get("documentSymbol", {}).get("hierarchicalDocumentSymbolSupport", False):
+    useHierarchicalSymbols = config.plugin_settings('jedi_symbols').get('hierarchical_symbols', None)
+    if useHierarchicalSymbols is None:
+        useHierarchicalSymbols = config.capabilities.get("documentSymbol", {}).get(
+            "hierarchicalDocumentSymbolSupport", False)
+    if not useHierarchicalSymbols:
         return pyls_document_symbols_legacy(config, document)
     # returns DocumentSymbol[]
     hide_imports = config.plugin_settings('jedi_symbols').get('hide_imports', False)

--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -1,6 +1,5 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
-from jedi.api.classes import Definition
 from pyls import hookimpl
 from pyls.lsp import SymbolKind
 
@@ -11,11 +10,11 @@ log = logging.getLogger(__name__)
 def pyls_document_symbols(config, document):
     # all_scopes = config.plugin_settings('jedi_symbols').get('all_scopes', True)
     definitions = document.jedi_names(all_scopes=False)
-    def transform(d: Definition):
-        includeD = _include_def(d)
-        if includeD is None:
+    def transform(d):
+        include_d = _include_def(d)
+        if include_d is None:
             return None
-        children = [dt for dt in (transform(d1) for d1 in d.defined_names()) if dt] if includeD else None
+        children = [dt for dt in (transform(d1) for d1 in d.defined_names()) if dt] if include_d else None
         detailName = d.full_name
         if detailName and detailName.startswith("__main__."):
             detailName = detailName[9:]

--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -13,6 +13,7 @@ def pyls_document_symbols(config, document):
     # returns DocumentSymbol[]
     hide_imports = config.plugin_settings('jedi_symbols').get('hide_imports', False)
     definitions = document.jedi_names(all_scopes=False)
+
     def transform(d):
         include_d = _include_def(d, hide_imports)
         if include_d is None:
@@ -31,6 +32,7 @@ def pyls_document_symbols(config, document):
         }
     return [dt for dt in (transform(d) for d in definitions) if dt]
 
+
 def pyls_document_symbols_legacy(config, document):
     # returns SymbolInformation[]
     all_scopes = config.plugin_settings('jedi_symbols').get('all_scopes', True)
@@ -46,11 +48,13 @@ def pyls_document_symbols_legacy(config, document):
         'kind': _kind(d),
     } for d in definitions if _include_def(d, hide_imports) is not None]
 
+
 def _include_def(definition, hide_imports=True):
+    # returns
     # True: include def and sub-defs
     # False: include def but do not include sub-defs
     # None: Do not include def or sub-defs
-    if (# Unused vars should also be skipped
+    if (  # Unused vars should also be skipped
             definition.name != '_' and
             definition.is_definition() and
             not definition.in_builtin_module() and

--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -10,8 +10,10 @@ log = logging.getLogger(__name__)
 def pyls_document_symbols(config, document):
     useHierarchicalSymbols = config.plugin_settings('jedi_symbols').get('hierarchical_symbols', None)
     if useHierarchicalSymbols is None:
-        useHierarchicalSymbols = config.capabilities.get("documentSymbol", {}).get(
-            "hierarchicalDocumentSymbolSupport", False)
+        useHierarchicalSymbols = (config.capabilities
+                                  .get("textDocument", {})
+                                  .get("documentSymbol", {})
+                                  .get("hierarchicalDocumentSymbolSupport", False))
     if not useHierarchicalSymbols:
         return pyls_document_symbols_legacy(config, document)
     # returns DocumentSymbol[]

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -78,6 +78,7 @@ def test_symbols_all_scopes(config):
     # Not going to get too in-depth here else we're just testing Jedi
     assert sym('a')['location']['range']['start'] == {'line': 2, 'character': 0}
 
+
 def test_symbols_hierarchical(config):
     doc = Document(DOC_URI, DOC)
 
@@ -95,6 +96,7 @@ def test_symbols_hierarchical(config):
 
     def sym(name):
         return [s for s in symbols if s['name'] == name][0]
+
     def child_sym(sym, name):
         if not sym['children']:
             return None

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -23,10 +23,16 @@ def main(x):
 
 def test_symbols(config):
     doc = Document(DOC_URI, DOC)
+    config.update({'plugins': {'jedi_symbols': {'all_scopes': False, 'hide_imports': True}}})
+    symbols = pyls_document_symbols(config, doc)
+
+    # Only local symbols (a, B, main, y)
+    assert len(symbols) == 4
+
     config.update({'plugins': {'jedi_symbols': {'all_scopes': False, 'hide_imports': False}}})
     symbols = pyls_document_symbols(config, doc)
 
-    # All four symbols (import sys, a, B, main, y)
+    # All five symbols (import sys, a, B, main, y)
     assert len(symbols) == 5
 
     def sym(name):
@@ -47,6 +53,14 @@ def test_symbols(config):
 
 def test_symbols_all_scopes(config):
     doc = Document(DOC_URI, DOC)
+
+    config.update({'plugins': {'jedi_symbols': {'all_scopes': True, 'hide_imports': True}}})
+    symbols = pyls_document_symbols(config, doc)
+
+    # Only local symbols (a, B, __init__, x, y, main, y)
+    assert len(symbols) == 7
+
+    config.update({'plugins': {'jedi_symbols': {'all_scopes': True, 'hide_imports': False}}})
     symbols = pyls_document_symbols(config, doc)
 
     # All eight symbols (import sys, a, B, __init__, x, y, main, y)
@@ -63,3 +77,33 @@ def test_symbols_all_scopes(config):
 
     # Not going to get too in-depth here else we're just testing Jedi
     assert sym('a')['location']['range']['start'] == {'line': 2, 'character': 0}
+
+def test_symbols_hierarchical(config):
+    doc = Document(DOC_URI, DOC)
+
+    config.update({'plugins': {'jedi_symbols': {'hierarchical_symbols': True, 'hide_imports': True}}})
+    symbols = pyls_document_symbols(config, doc)
+
+    # Only local symbols (a, B, main, y)
+    assert len(symbols) == 4
+
+    config.update({'plugins': {'jedi_symbols': {'hierarchical_symbols': True, 'hide_imports': False}}})
+    symbols = pyls_document_symbols(config, doc)
+
+    # All five symbols (import sys, a, B, main, y)
+    assert len(symbols) == 5
+
+    def sym(name):
+        return [s for s in symbols if s['name'] == name][0]
+    def child_sym(sym, name):
+        if not sym['children']:
+            return None
+        return [s for s in sym['children'] if s['name'] == name][0]
+
+    # Check we have some sane mappings to VSCode constants
+    assert sym('a')['kind'] == SymbolKind.Variable
+    assert sym('B')['kind'] == SymbolKind.Class
+    assert len(sym('B')['children']) == 1
+    assert child_sym(sym('B'), '__init__')['kind'] == SymbolKind.Function
+    assert child_sym(sym('B'), '__init__')['detail'] == 'B.__init__'
+    assert sym('main')['kind'] == SymbolKind.Function

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -23,7 +23,7 @@ def main(x):
 
 def test_symbols(config):
     doc = Document(DOC_URI, DOC)
-    config.update({'plugins': {'jedi_symbols': {'all_scopes': False}}})
+    config.update({'plugins': {'jedi_symbols': {'all_scopes': False, 'hide_imports': False}}})
     symbols = pyls_document_symbols(config, doc)
 
     # All four symbols (import sys, a, B, main, y)


### PR DESCRIPTION
c.f. #407 

This PR should make [`textDocument/documentSymbol`](https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol) reponse use the new `DocumentSymbol` contract. This means you can have a list of `children` for each parent symbols. Now the `documentSymbol` is something like this

```json
{
    "jsonrpc": "2.0",
    "id": "2",
    "result": [
        {
            "name": "ReadFields",
            "detail": "ReadFields",
            "range": {
                "start": {
                    "line": 3,
                    "character": 0
                },
                "end": {
                    "line": 19,
                    "character": 0
                }
            },
            "selectionRange": {
                "start": {
                    "line": 3,
                    "character": 4
                },
                "end": {
                    "line": 3,
                    "character": 14
                }
            },
            "kind": 12,
            "children": [
                {
                    "name": "closeFile",
                    "detail": "ReadFields.closeFile",
                    "range": {
                        "start": {
                            "line": 7,
                            "character": 4
                        },
                        "end": {
                            "line": 7,
                            "character": 21
                        }
                    },
                    "selectionRange": {
                        "start": {
                            "line": 7,
                            "character": 4
                        },
                        "end": {
                            "line": 7,
                            "character": 13
                        }
                    },
                    "kind": 13,
                    "children": null
                },
                {
                    "name": "f",
                    "detail": "ReadFields.f",
                    "range": {
                        "start": {
                            "line": 9,
                            "character": 8
                        },
                        "end": {
                            "line": 9,
                            "character": 22
                        }
                    },
                    "selectionRange": {
                        "start": {
                            "line": 9,
                            "character": 8
                        },
                        "end": {
                            "line": 9,
                            "character": 9
                        }
                    },
                    "kind": 13,
                    "children": null
                },
                {
                    "name": "closeFile",
                    "detail": "ReadFields.closeFile",
                    "range": {
                        "start": {
                            "line": 10,
                            "character": 8
                        },
                        "end": {
                            "line": 10,
                            "character": 24
                        }
                    },
                    "selectionRange": {
                        "start": {
                            "line": 10,
                            "character": 8
                        },
                        "end": {
                            "line": 10,
                            "character": 17
                        }
                    },
                    "kind": 13,
                    "children": null
                },
                {
                    "name": "l",
                    "detail": "ReadFields.l",
                    "range": {
                        "start": {
                            "line": 14,
                            "character": 8
                        },
                        "end": {
                            "line": 17,
                            "character": 0
                        }
                    },
                    "selectionRange": {
                        "start": {
                            "line": 14,
                            "character": 12
                        },
                        "end": {
                            "line": 14,
                            "character": 13
                        }
                    },
                    "kind": 13,
                    "children": null
                },
...
```
Python source code for reference
```python
import io
from os import path

def ReadFields(f) :
    '''
    f : io.IOBase or str
    '''
    closeFile = False
    if isinstance(f, str) : 
        f = io.open(f)
        closeFile = True
    elif isinstance(f, io.IOBase) : pass
    else : raise TypeError
    try :
        for l in f :
            l = str(l).strip()
            if len(l) > 0 : yield l.split()
    finally :
        if closeFile : f.close()
...
```

Unfortunately, I haven't tested it thoroughly in VSCode because I simply couldn't start Extension Development Host with `yarn run vscode`.