### PR TITLE
Discovery and use of pylint config file for pylint lint plugin

### DIFF
--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -70,6 +70,7 @@ def find_parents(root, path, names):
     # Otherwise nothing
     return []
 
+
 def search(root, names, depth=4):
     """Find the first file matching the given names below the given path.
 
@@ -83,18 +84,20 @@ def search(root, names, depth=4):
         log.warning("find_up called with empty root directory.")
         return []
 
-    if not depth > -1:
+    if depth < 0:
         log.warning("Depth %d smaller than zero.", depth)
         return []
 
     start_seps = root.count(os.sep)
 
     result = []
-    
-    for top, dirs, files in os.walk(root):
+
+    for top, _dirs, files in os.walk(root):
         if top.count(os.sep) - start_seps > depth:
             break
-        [result.append(os.path.join(top, f)) for f in files if f in names]
+        for f in files:
+            if f in names:
+                result.append(os.path.join(top, f))
 
     return result
 

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -70,6 +70,34 @@ def find_parents(root, path, names):
     # Otherwise nothing
     return []
 
+def search(root, names, depth=4):
+    """Find the first file matching the given names below the given path.
+
+    Args:
+        root (str): Where to start searching down from.
+        depth (int): How deep to search.
+
+    Note: Does not follow links.
+    """
+    if not root:
+        log.warning("find_up called with empty root directory.")
+        return []
+
+    if not depth > -1:
+        log.warning("Depth %d smaller than zero.", depth)
+        return []
+
+    start_seps = root.count(os.sep)
+
+    result = []
+    
+    for top, dirs, files in os.walk(root):
+        if top.count(os.sep) - start_seps > depth:
+            break
+        [result.append(os.path.join(top, f)) for f in files if f in names]
+
+    return result
+
 
 def list_to_string(value):
     return ",".join(value) if isinstance(value, list) else value

--- a/pyls/config/config.py
+++ b/pyls/config/config.py
@@ -40,6 +40,12 @@ class Config(object):
         except ImportError:
             pass
 
+        try:
+            from .pylint_conf import PylintConfig
+            self._config_sources['pylint'] = PylintConfig(self._root_path)
+        except ImportError:
+            pass
+
         self._pm = pluggy.PluginManager(PYLS)
         self._pm.trace.root.setwriter(log.debug)
         self._pm.enable_tracing()

--- a/pyls/config/pylint_conf.py
+++ b/pyls/config/pylint_conf.py
@@ -10,12 +10,25 @@ PROJECT_CONFIGS = ['.pylintrc', 'pylintrc']
 RCFILE_CONFIG = 'plugins.pylint.rcfile'
 
 
+def set_dict_path(d, path, value):
+    current = d
+    elems = path.split(".")
+    for elem in elems[:-1]:
+        if elem not in current.keys():
+            current[elem] = {}
+        current = current[elem]
+    current[elems[-1]] = value
+    return d
+
+
 class PylintConfig(ConfigSource):
     """Parse pylint configurations."""
 
     def user_config(self):
         config_file = self._user_config_file()
-        return {RCFILE_CONFIG: config_file}
+        if os.path.isfile(config_file):
+            return set_dict_path({}, RCFILE_CONFIG, config_file)
+        return {}
 
     def _user_config_file(self):
         if self.is_windows:
@@ -25,5 +38,5 @@ class PylintConfig(ConfigSource):
     def project_config(self, document_path):
         files = find_parents(self.root_path, document_path, PROJECT_CONFIGS)
         if files:
-            return {RCFILE_CONFIG: files[0]}
+            return set_dict_path({}, RCFILE_CONFIG, files[0])
         return {}

--- a/pyls/config/pylint_conf.py
+++ b/pyls/config/pylint_conf.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
 import os
-from pyls._utils import find_parents
+from pyls._utils import search
 from .source import ConfigSource
 
 log = logging.getLogger(__name__)
@@ -36,7 +36,10 @@ class PylintConfig(ConfigSource):
         return os.path.join(self.xdg_home, '.pylintrc')
 
     def project_config(self, document_path):
-        files = find_parents(self.root_path, document_path, PROJECT_CONFIGS)
+        log.debug("Searching for config files called %s from %s to %s.",
+                  PROJECT_CONFIGS, document_path, self.root_path)
+        files = search(self.root_path, PROJECT_CONFIGS)
+        log.debug("Found pylint project config files %s.", files)
         if files:
             return set_dict_path({}, RCFILE_CONFIG, files[0])
         return {}

--- a/pyls/config/pylint_conf.py
+++ b/pyls/config/pylint_conf.py
@@ -7,20 +7,14 @@ from .source import ConfigSource
 log = logging.getLogger(__name__)
 
 PROJECT_CONFIGS = ['.pylintrc', 'pylintrc']
-
-OPTIONS = [
-    (('MESSAGES CONTROL', 'disable'), 'plugins.pylint.disable', list),
-    # Will need to be expanded later.
-]
-
+RCFILE_CONFIG = 'plugins.pylint.rcfile'
 
 class PylintConfig(ConfigSource):
     """Parse pylint configurations."""
 
     def user_config(self):
         config_file = self._user_config_file()
-        config = self.read_config_from_files([config_file])
-        return self.parse_config(config, OPTIONS)
+        return {RCFILE_CONFIG: config_file}
 
     def _user_config_file(self):
         if self.is_windows:
@@ -29,5 +23,7 @@ class PylintConfig(ConfigSource):
 
     def project_config(self, document_path):
         files = find_parents(self.root_path, document_path, PROJECT_CONFIGS)
-        config = self.read_config_from_files(files)
-        return self.parse_config(config, OPTIONS)
+        if len(files) > 0:
+            return {RCFILE_CONFIG: files[0]}
+        else:
+            return {}

--- a/pyls/config/pylint_conf.py
+++ b/pyls/config/pylint_conf.py
@@ -9,6 +9,7 @@ log = logging.getLogger(__name__)
 PROJECT_CONFIGS = ['.pylintrc', 'pylintrc']
 RCFILE_CONFIG = 'plugins.pylint.rcfile'
 
+
 class PylintConfig(ConfigSource):
     """Parse pylint configurations."""
 
@@ -23,7 +24,6 @@ class PylintConfig(ConfigSource):
 
     def project_config(self, document_path):
         files = find_parents(self.root_path, document_path, PROJECT_CONFIGS)
-        if len(files) > 0:
+        if files:
             return {RCFILE_CONFIG: files[0]}
-        else:
-            return {}
+        return {}

--- a/pyls/config/pylint_conf.py
+++ b/pyls/config/pylint_conf.py
@@ -1,0 +1,33 @@
+# Copyright 2017 Palantir Technologies, Inc.
+import logging
+import os
+from pyls._utils import find_parents
+from .source import ConfigSource
+
+log = logging.getLogger(__name__)
+
+PROJECT_CONFIGS = ['.pylintrc', 'pylintrc']
+
+OPTIONS = [
+    (('MESSAGES CONTROL', 'disable'), 'plugins.pylint.disable', list),
+    # Will need to be expanded later.
+]
+
+
+class PylintConfig(ConfigSource):
+    """Parse pylint configurations."""
+
+    def user_config(self):
+        config_file = self._user_config_file()
+        config = self.read_config_from_files([config_file])
+        return self.parse_config(config, OPTIONS)
+
+    def _user_config_file(self):
+        if self.is_windows:
+            return os.path.expanduser('~\\.pylintrc')
+        return os.path.join(self.xdg_home, '.pylintrc')
+
+    def project_config(self, document_path):
+        files = find_parents(self.root_path, document_path, PROJECT_CONFIGS)
+        config = self.read_config_from_files(files)
+        return self.parse_config(config, OPTIONS)

--- a/pyls/plugins/pylint_lint.py
+++ b/pyls/plugins/pylint_lint.py
@@ -21,7 +21,7 @@ class PylintLinter(object):
         log.debug("Trying to set config file flags.")
         rcfile = config.plugin_settings('pylint').get(CONFIG_FILE, None)
         if rcfile:
-            log.debug("Setting pylint configuration file «%s».", rcfile)
+            log.debug("Setting pylint configuration file '%s'.", rcfile)
             return flags + ' --rcfile ' + rcfile
         return flags
 

--- a/pyls/plugins/pylint_lint.py
+++ b/pyls/plugins/pylint_lint.py
@@ -60,7 +60,7 @@ class PylintLinter(object):
         if sys.platform.startswith('win'):
             path = path.replace('\\', '/')
 
-        rcfile = config.plugin.settings('pylint').get(CONFIG_FILE, None)
+        rcfile = config.plugin_settings('pylint').get(CONFIG_FILE, None)
         if rcfile is not None:
             flags = flags + ' --rcfile ' + rcfile
 

--- a/pyls/plugins/pylint_lint.py
+++ b/pyls/plugins/pylint_lint.py
@@ -18,8 +18,10 @@ class PylintLinter(object):
 
     @staticmethod
     def add_rc_to_flags(config, flags):
+        log.debug("Trying to set config file flags.")
         rcfile = config.plugin_settings('pylint').get(CONFIG_FILE, None)
         if rcfile:
+            log.debug("Setting pylint configuration file «%s».", rcfile)
             return flags + ' --rcfile ' + rcfile
         return flags
 
@@ -28,6 +30,7 @@ class PylintLinter(object):
         """Plugin interface to pyls linter.
 
         Args:
+            config: The configuration. Used to get configuration file setting.
             document: The document to be linted.
             is_saved: Whether or not the file has been saved to disk.
             flags: Additional flags to pass to pylint. Not exposed to

--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -20,6 +20,11 @@ DOC_SYNTAX_ERR = """def hello()
     pass
 """
 
+PYLINTRC = """
+[MESSAGES CONTROL]
+disable=all
+"""
+
 
 @contextlib.contextmanager
 def temp_document(doc_text):
@@ -33,14 +38,25 @@ def temp_document(doc_text):
         os.remove(name)
 
 
+@contextlib.contextmanager
+def named_tempfile(path, content):
+    try:
+        f = open(path, "w")
+        f.write(content)
+        f.close()
+        yield f
+    finally:
+        os.remove(path)
+
+
 def write_temp_doc(document, contents):
     with open(document.path, 'w') as temp_file:
         temp_file.write(contents)
 
 
-def test_pylint():
+def test_pylint(config):
     with temp_document(DOC) as doc:
-        diags = pylint_lint.pyls_lint(doc, True)
+        diags = pylint_lint.pyls_lint(config, doc, True)
 
         msg = '[unused-import] Unused import sys'
         unused_import = [d for d in diags if d['message'] == msg][0]
@@ -49,9 +65,9 @@ def test_pylint():
         assert unused_import['severity'] == lsp.DiagnosticSeverity.Warning
 
 
-def test_syntax_error_pylint():
+def test_syntax_error_pylint(config):
     with temp_document(DOC_SYNTAX_ERR) as doc:
-        diag = pylint_lint.pyls_lint(doc, True)[0]
+        diag = pylint_lint.pyls_lint(config, doc, True)[0]
 
         assert diag['message'].startswith('[syntax-error] invalid syntax')
         # Pylint doesn't give column numbers for invalid syntax.
@@ -59,15 +75,15 @@ def test_syntax_error_pylint():
         assert diag['severity'] == lsp.DiagnosticSeverity.Error
 
 
-def test_lint_free_pylint():
+def test_lint_free_pylint(config):
     # Can't use temp_document because it might give us a file that doesn't
     # match pylint's naming requirements. We should be keeping this file clean
     # though, so it works for a test of an empty lint.
-    assert not pylint_lint.pyls_lint(
-        Document(uris.from_fs_path(__file__)), True)
+    assert not pylint_lint.pyls_lint(config,
+                                     Document(uris.from_fs_path(__file__)), True)
 
 
-def test_lint_caching():
+def test_lint_caching(config):
     # Pylint can only operate on files, not in-memory contents. We cache the
     # diagnostics after a run so we can continue displaying them until the file
     # is saved again.
@@ -80,25 +96,34 @@ def test_lint_caching():
     flags = '--disable=invalid-name'
     with temp_document(DOC) as doc:
         # Start with a file with errors.
-        diags = pylint_lint.PylintLinter.lint(doc, True, flags)
+        diags = pylint_lint.PylintLinter.lint(config, doc, True, flags)
         assert diags
 
         # Fix lint errors and write the changes to disk. Run the linter in the
         # in-memory mode to check the cached diagnostic behavior.
         write_temp_doc(doc, '')
-        assert pylint_lint.PylintLinter.lint(doc, False, flags) == diags
+        assert pylint_lint.PylintLinter.lint(config, doc, False, flags) == diags
 
         # Now check the on-disk behavior.
-        assert not pylint_lint.PylintLinter.lint(doc, True, flags)
+        assert not pylint_lint.PylintLinter.lint(config, doc, True, flags)
 
         # Make sure the cache was properly cleared.
-        assert not pylint_lint.PylintLinter.lint(doc, False, flags)
+        assert not pylint_lint.PylintLinter.lint(config, doc, False, flags)
 
 
-def test_per_file_caching():
+def test_per_file_caching(config):
     # Ensure that diagnostics are cached per-file.
     with temp_document(DOC) as doc:
-        assert pylint_lint.pyls_lint(doc, True)
+        assert pylint_lint.pyls_lint(config, doc, True)
 
-    assert not pylint_lint.pyls_lint(
-        Document(uris.from_fs_path(__file__)), False)
+    assert not pylint_lint.pyls_lint(config,
+                                     Document(uris.from_fs_path(__file__)), False)
+
+
+def test_with_config_file(config):
+    with temp_document(DOC) as doc:
+        with named_tempfile(os.path.join(os.path.dirname(doc.path), ".pylintrc"),
+                            PYLINTRC)\
+             as configfile:
+            config.update({'plugins': {'pylint': {'rcfile': configfile.name}}})
+            assert not pylint_lint.pyls_lint(config, doc, True)

--- a/test/plugins/test_pylint_lint.py
+++ b/test/plugins/test_pylint_lint.py
@@ -122,8 +122,6 @@ def test_per_file_caching(config):
 
 def test_with_config_file(config):
     with temp_document(DOC) as doc:
-        with named_tempfile(os.path.join(os.path.dirname(doc.path), ".pylintrc"),
-                            PYLINTRC)\
-             as configfile:
+        with named_tempfile(os.path.join(os.path.dirname(doc.path), ".pylintrc"), PYLINTRC) as configfile:
             config.update({'plugins': {'pylint': {'rcfile': configfile.name}}})
             assert not pylint_lint.pyls_lint(config, doc, True)


### PR DESCRIPTION
I've added functionality to make the `pylint` plugin find the `pylintrc` config file and use it. I've added a `rcfile` plugin option for the pylint plugin that is populated with the path of any found pylint config file.

Also included is a test that checks whether the config file is passed correctly.

Settings for other plugins are broken out from their config file, but the number of settings for pylint is huge, and passing all options from the config file into the `flags` argument of `Pylint.lint()` would require a huge amount of work. This is a useful first implementation.