### PR TITLE
Add support for multiple workspaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: pip install -e .[all] .[test]
-      - run: py.test test/
+      - run: py.test -v test/
       - run: pylint pyls test
       - run: pycodestyle pyls test
       - run: pyflakes pyls test
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - run: pip install -e .[all] .[test]
-      - run: py.test test/
+      - run: py.test -v test/
 
   lint:
     docker:

--- a/.pylintrc
+++ b/.pylintrc
@@ -15,7 +15,8 @@ disable =
     protected-access,
     too-few-public-methods,
     too-many-arguments,
-    too-many-instance-attributes
+    too-many-instance-attributes,
+    import-error
 
 [REPORTS]
 

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -86,7 +86,7 @@ def match_uri_to_workspace(uri, workspaces):
     path = pathlib.Path(uri).parts
     for workspace in workspaces:
         try:
-            workspace_parts = pathlib.Path(to_text_string(workspace)).parts
+            workspace_parts = pathlib.Path(workspace).parts
         except TypeError:
             # This can happen in Python2 if 'value' is a subclass of string
             workspace_parts = pathlib.Path(unicode(workspace)).parts
@@ -163,24 +163,3 @@ def is_process_alive(pid):
         return False
     else:
         return True
-
-
-def to_text_string(obj, encoding=None):
-    """Convert `obj` to (unicode) text string"""
-    if PY2:
-        if isinstance(obj, unicode):
-            return obj
-        # Python 2
-        if encoding is None:
-            return unicode(obj)
-        else:
-            return unicode(obj, encoding)
-    else:
-        # Python 3
-        if encoding is None:
-            return str(obj)
-        elif isinstance(obj, str):
-            # In case this function is not used properly, this could happen
-            return obj
-        else:
-            return str(obj, encoding)

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -85,7 +85,11 @@ def match_uri_to_workspace(uri, workspaces):
     max_len, chosen_workspace = -1, None
     path = pathlib.Path(uri).parts
     for workspace in workspaces:
-        workspace_parts = pathlib.Path(to_text_string(workspace)).parts
+        try:
+            workspace_parts = pathlib.Path(to_text_string(workspace)).parts
+        except TypeError:
+            # This can happen in Python2 if 'value' is a subclass of string
+            workspace_parts = pathlib.Path(unicode(workspace)).parts
         if len(workspace_parts) > len(path):
             continue
         match_len = 0

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -159,3 +159,24 @@ def is_process_alive(pid):
         return False
     else:
         return True
+
+
+def to_text_string(obj, encoding=None):
+    """Convert `obj` to (unicode) text string"""
+    if PY2:
+        if isinstance(obj, unicode):
+            return obj
+        # Python 2
+        if encoding is None:
+            return unicode(obj)
+        else:
+            return unicode(obj, encoding)
+    else:
+        # Python 3
+        if encoding is None:
+            return str(obj)
+        elif isinstance(obj, str):
+            # In case this function is not used properly, this could happen
+            return obj
+        else:
+            return str(obj, encoding)

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -3,7 +3,15 @@ import functools
 import inspect
 import logging
 import os
+import sys
 import threading
+
+PY2 = sys.version_info.major == 2
+
+if PY2:
+    import pathlib2 as pathlib
+else:
+    import pathlib
 
 log = logging.getLogger(__name__)
 
@@ -69,6 +77,26 @@ def find_parents(root, path, names):
 
     # Otherwise nothing
     return []
+
+
+def match_uri_to_workspace(uri, workspaces):
+    if uri is None:
+        return None
+    max_len, chosen_workspace = -1, None
+    path = pathlib.Path(uri).parts
+    for workspace in workspaces:
+        workspace_parts = pathlib.Path(workspace).parts
+        if len(workspace_parts) > len(path):
+            continue
+        match_len = 0
+        for workspace_part, path_part in zip(workspace_parts, path):
+            if workspace_part == path_part:
+                match_len += 1
+        if match_len > 0:
+            if match_len > max_len:
+                max_len = match_len
+                chosen_workspace = workspace
+    return chosen_workspace
 
 
 def list_to_string(value):

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -85,7 +85,7 @@ def match_uri_to_workspace(uri, workspaces):
     max_len, chosen_workspace = -1, None
     path = pathlib.Path(uri).parts
     for workspace in workspaces:
-        workspace_parts = pathlib.Path(workspace).parts
+        workspace_parts = pathlib.Path(to_text_string(workspace)).parts
         if len(workspace_parts) > len(path):
             continue
         match_len = 0

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -332,6 +332,14 @@ class PythonLanguageServer(MethodDispatcher):
             added_uri = added_info['uri']
             self.workspaces[added_uri] = Workspace(added_uri, self._endpoint)
 
+        # Migrate documents that are on the root workspace and have a better
+        # match now
+        doc_uris = list(self.workspace._docs.keys())
+        for uri in doc_uris:
+            doc = self.workspace._docs.pop(uri)
+            new_workspace = self._match_uri_to_workspace(uri)
+            new_workspace._docs[uri] = doc
+
     def m_workspace__did_change_watched_files(self, changes=None, **_kwargs):
         changed_py_files = set()
         config_changed = False

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -170,7 +170,6 @@ class PythonLanguageServer(MethodDispatcher):
         if rootUri is None:
             rootUri = uris.from_fs_path(rootPath) if rootPath is not None else ''
 
-        rootUri = _utils.to_text_string(rootUri)
         self.workspaces.pop(self.root_uri, None)
         self.root_uri = rootUri
         self.workspace = Workspace(rootUri, self._endpoint)

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -153,6 +153,12 @@ class PythonLanguageServer(MethodDispatcher):
                 'triggerCharacters': ['(', ',', '=']
             },
             'textDocumentSync': lsp.TextDocumentSyncKind.INCREMENTAL,
+            'workspace': {
+                'workspaceFolders': {
+                    'supported': True,
+                    'changeNotifications': True
+                }
+            },
             'experimental': merge(self._hook('pyls_experimental_capabilities'))
         }
         log.info('Server capabilities: %s', server_capabilities)

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -73,8 +73,9 @@ class PythonLanguageServer(MethodDispatcher):
     # pylint: disable=too-many-public-methods,redefined-builtin
 
     def __init__(self, rx, tx, check_parent_process=False):
-        self.workspace = None
+        self.root_workspace = None
         self.config = None
+        self.root_uri = None
         self.workspaces = {}
         self.uri_workspace_mapper = {}
 
@@ -119,7 +120,7 @@ class PythonLanguageServer(MethodDispatcher):
 
     def _match_uri_to_workspace(self, uri):
         workspace_uri = _utils.match_uri_to_workspace(uri, self.workspaces)
-        return self.workspaces.get(workspace_uri, None)
+        return self.workspaces.get(workspace_uri, self.root_workspace)
 
     def _hook(self, hook_name, doc_uri=None, **kwargs):
         """Calls hook_name and returns a list of results from all registered handlers"""
@@ -169,8 +170,10 @@ class PythonLanguageServer(MethodDispatcher):
         if rootUri is None:
             rootUri = uris.from_fs_path(rootPath) if rootPath is not None else ''
 
-        self.workspace = Workspace(rootUri, self._endpoint)
-        self.workspaces[rootUri] = self.workspace
+        self.workspaces.pop(self.root_uri, None)
+        self.root_uri = rootUri
+        self.root_workspace = Workspace(rootUri, self._endpoint)
+        self.workspaces[rootUri] = self.root_workspace
         self.config = config.Config(rootUri, initializationOptions or {},
                                     processId, _kwargs.get('capabilities', {}))
         self._dispatchers = self._hook('pyls_dispatchers')

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -170,6 +170,7 @@ class PythonLanguageServer(MethodDispatcher):
         if rootUri is None:
             rootUri = uris.from_fs_path(rootPath) if rootPath is not None else ''
 
+        rootUri = _utils.to_text_string(rootUri)
         self.workspaces.pop(self.root_uri, None)
         self.root_uri = rootUri
         self.workspace = Workspace(rootUri, self._endpoint)

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -73,7 +73,7 @@ class PythonLanguageServer(MethodDispatcher):
     # pylint: disable=too-many-public-methods,redefined-builtin
 
     def __init__(self, rx, tx, check_parent_process=False):
-        self.root_workspace = None
+        self.workspace = None
         self.config = None
         self.root_uri = None
         self.workspaces = {}
@@ -120,7 +120,7 @@ class PythonLanguageServer(MethodDispatcher):
 
     def _match_uri_to_workspace(self, uri):
         workspace_uri = _utils.match_uri_to_workspace(uri, self.workspaces)
-        return self.workspaces.get(workspace_uri, self.root_workspace)
+        return self.workspaces.get(workspace_uri, self.workspace)
 
     def _hook(self, hook_name, doc_uri=None, **kwargs):
         """Calls hook_name and returns a list of results from all registered handlers"""
@@ -172,8 +172,8 @@ class PythonLanguageServer(MethodDispatcher):
 
         self.workspaces.pop(self.root_uri, None)
         self.root_uri = rootUri
-        self.root_workspace = Workspace(rootUri, self._endpoint)
-        self.workspaces[rootUri] = self.root_workspace
+        self.workspace = Workspace(rootUri, self._endpoint)
+        self.workspaces[rootUri] = self.workspace
         self.config = config.Config(rootUri, initializationOptions or {},
                                     processId, _kwargs.get('capabilities', {}))
         self._dispatchers = self._hook('pyls_dispatchers')

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -125,7 +125,7 @@ class PythonLanguageServer(MethodDispatcher):
     def _hook(self, hook_name, doc_uri=None, **kwargs):
         """Calls hook_name and returns a list of results from all registered handlers"""
         workspace = self._match_uri_to_workspace(doc_uri)
-        doc = workspace.get_document(doc_uri) if workspace else None
+        doc = workspace.get_document(doc_uri) if doc_uri else None
         hook_handlers = self.config.plugin_manager.subset_hook_caller(hook_name, self.config.disabled_plugins)
         return hook_handlers(config=self.config, workspace=workspace, document=doc, **kwargs)
 

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -1,8 +1,22 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import os
+import sys
+import os.path as osp
 from pyls import uris
 
+PY2 = sys.version_info.major == 2
+
+if PY2:
+    import pathlib2 as pathlib
+else:
+    import pathlib
+
+
 DOC_URI = uris.from_fs_path(__file__)
+
+
+def path_as_uri(path):
+    return pathlib.Path(osp.abspath(path)).as_uri()
 
 
 def test_local(pyls):
@@ -48,3 +62,47 @@ def test_non_root_project(pyls):
     pyls.workspace.put_document(test_uri, 'assert True')
     test_doc = pyls.workspace.get_document(test_uri)
     assert project_root in test_doc.sys_path()
+
+
+def test_multiple_workspaces(tmpdir, pyls):
+    workspace1_dir = tmpdir.mkdir('workspace1')
+    workspace2_dir = tmpdir.mkdir('workspace2')
+    file1 = workspace1_dir.join('file1.py')
+    file2 = workspace2_dir.join('file1.py')
+    file1.write('import os')
+    file2.write('import sys')
+
+    msg = {
+        'uri': path_as_uri(str(file1)),
+        'version': 1,
+        'text': 'import os'
+    }
+
+    pyls.m_text_document__did_open(textDocument=msg)
+    assert msg['uri'] in pyls.workspace._docs
+
+    added_workspaces = [{'uri': path_as_uri(str(x))}
+                        for x in (workspace1_dir, workspace2_dir)]
+    pyls.m_workspace__did_change_workspace_folders(
+        added=added_workspaces, removed=[])
+
+    for workspace in added_workspaces:
+        assert workspace['uri'] in pyls.workspaces
+
+    workspace1_uri = added_workspaces[0]['uri']
+    assert msg['uri'] not in pyls.workspace._docs
+    assert msg['uri'] in pyls.workspaces[workspace1_uri]._docs
+
+    msg = {
+        'uri': path_as_uri(str(file2)),
+        'version': 1,
+        'text': 'import sys'
+    }
+    pyls.m_text_document__did_open(textDocument=msg)
+
+    workspace2_uri = added_workspaces[1]['uri']
+    assert msg['uri'] in pyls.workspaces[workspace2_uri]._docs
+
+    pyls.m_workspace__did_change_workspace_folders(
+        added=[], removed=[added_workspaces[0]])
+    assert workspace1_uri not in pyls.workspaces

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -1,9 +1,8 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import os
-import sys
 import os.path as osp
+import sys
 from pyls import uris
-from pyls._utils import to_text_string
 
 PY2 = sys.version_info.major == 2
 
@@ -74,7 +73,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     file2.write('import sys')
 
     msg = {
-        'uri': path_as_uri(to_text_string(file1)),
+        'uri': path_as_uri(str(file1)),
         'version': 1,
         'text': 'import os'
     }
@@ -82,7 +81,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     pyls.m_text_document__did_open(textDocument=msg)
     assert msg['uri'] in pyls.workspace._docs
 
-    added_workspaces = [{'uri': path_as_uri(to_text_string(x))}
+    added_workspaces = [{'uri': path_as_uri(str(x))}
                         for x in (workspace1_dir, workspace2_dir)]
     pyls.m_workspace__did_change_workspace_folders(
         added=added_workspaces, removed=[])
@@ -95,7 +94,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     assert msg['uri'] in pyls.workspaces[workspace1_uri]._docs
 
     msg = {
-        'uri': path_as_uri(to_text_string(file2)),
+        'uri': path_as_uri(str(file2)),
         'version': 1,
         'text': 'import sys'
     }

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -19,6 +19,7 @@ DOC_URI = uris.from_fs_path(__file__)
 def path_as_uri(path):
     return pathlib.Path(osp.abspath(path)).as_uri()
 
+
 def test_local(pyls):
     """ Since the workspace points to the test directory """
     assert pyls.workspace.is_local()
@@ -73,7 +74,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     file2.write('import sys')
 
     msg = {
-        'uri': to_text_string(path_as_uri(to_text_string(file1))),
+        'uri': path_as_uri(to_text_string(file1)),
         'version': 1,
         'text': 'import os'
     }
@@ -81,7 +82,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     pyls.m_text_document__did_open(textDocument=msg)
     assert msg['uri'] in pyls.workspace._docs
 
-    added_workspaces = [{'uri': to_text_string(path_as_uri(to_text_string(x)))}
+    added_workspaces = [{'uri': path_as_uri(to_text_string(x))}
                         for x in (workspace1_dir, workspace2_dir)]
     pyls.m_workspace__did_change_workspace_folders(
         added=added_workspaces, removed=[])
@@ -94,7 +95,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     assert msg['uri'] in pyls.workspaces[workspace1_uri]._docs
 
     msg = {
-        'uri': to_text_string(path_as_uri(to_text_string(file2))),
+        'uri': path_as_uri(to_text_string(file2)),
         'version': 1,
         'text': 'import sys'
     }

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -3,6 +3,7 @@ import os
 import sys
 import os.path as osp
 from pyls import uris
+from pyls._utils import to_text_string
 
 PY2 = sys.version_info.major == 2
 
@@ -17,28 +18,6 @@ DOC_URI = uris.from_fs_path(__file__)
 
 def path_as_uri(path):
     return pathlib.Path(osp.abspath(path)).as_uri()
-
-
-def to_text_string(obj, encoding=None):
-    """Convert `obj` to (unicode) text string"""
-    if PY2:
-        if isinstance(obj, unicode):
-            return obj
-        # Python 2
-        if encoding is None:
-            return unicode(obj)
-        else:
-            return unicode(obj, encoding)
-    else:
-        # Python 3
-        if encoding is None:
-            return str(obj)
-        elif isinstance(obj, str):
-            # In case this function is not used properly, this could happen
-            return obj
-        else:
-            return str(obj, encoding)
-
 
 def test_local(pyls):
     """ Since the workspace points to the test directory """

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -19,6 +19,27 @@ def path_as_uri(path):
     return pathlib.Path(osp.abspath(path)).as_uri()
 
 
+def to_text_string(obj, encoding=None):
+    """Convert `obj` to (unicode) text string"""
+    if PY2:
+        if isinstance(obj, unicode):
+            return obj
+        # Python 2
+        if encoding is None:
+            return unicode(obj)
+        else:
+            return unicode(obj, encoding)
+    else:
+        # Python 3
+        if encoding is None:
+            return str(obj)
+        elif isinstance(obj, str):
+            # In case this function is not used properly, this could happen
+            return obj
+        else:
+            return str(obj, encoding)
+
+
 def test_local(pyls):
     """ Since the workspace points to the test directory """
     assert pyls.workspace.is_local()
@@ -73,7 +94,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     file2.write('import sys')
 
     msg = {
-        'uri': path_as_uri(str(file1)),
+        'uri': to_text_string(path_as_uri(to_text_string(file1))),
         'version': 1,
         'text': 'import os'
     }
@@ -81,7 +102,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     pyls.m_text_document__did_open(textDocument=msg)
     assert msg['uri'] in pyls.workspace._docs
 
-    added_workspaces = [{'uri': path_as_uri(str(x))}
+    added_workspaces = [{'uri': to_text_string(path_as_uri(to_text_string(x)))}
                         for x in (workspace1_dir, workspace2_dir)]
     pyls.m_workspace__did_change_workspace_folders(
         added=added_workspaces, removed=[])
@@ -94,7 +115,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     assert msg['uri'] in pyls.workspaces[workspace1_uri]._docs
 
     msg = {
-        'uri': path_as_uri(str(file2)),
+        'uri': to_text_string(path_as_uri(to_text_string(file2))),
         'version': 1,
         'text': 'import sys'
     }


### PR DESCRIPTION
This PR enables multi-root support for pyls, thus, enabling a single server to manage multiple workspaces for a single client.

cc @ccordoba12