### PR TITLE
Don't use Jedi 0.14 for now because it breaks the server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'future>=0.14.0',
         'futures; python_version<"3.2"',
         'backports.functools_lru_cache; python_version<"3.2"',
-        'jedi>=0.13.2',
+        'jedi>=0.13.2,<0.14',
         'python-jsonrpc-server>=0.1.0',
         'pluggy'
     ],


### PR DESCRIPTION
I discovered this through the Spyder testing suite this morning. We'll add support for this new version as soon as we can, but for now we need to release a new version of the PyLS that avoids using it.