### PR TITLE
Explicitly define our `TestDocumentSync` capabilities

### DIFF
--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -145,7 +145,13 @@ class PythonLanguageServer(MethodDispatcher):
             'signatureHelpProvider': {
                 'triggerCharacters': ['(', ',', '=']
             },
-            'textDocumentSync': lsp.TextDocumentSyncKind.INCREMENTAL,
+            'textDocumentSync': {
+                'change': lsp.TextDocumentSyncKind.INCREMENTAL,
+                'save': {
+                    'includeText': True,
+                },
+                'openClose': True,
+            },
             'experimental': merge(self._hook('pyls_experimental_capabilities'))
         }
         log.info('Server capabilities: %s', server_capabilities)


### PR DESCRIPTION
According to specification, passing a number in `TextDocumentSync` is for legacy support. I think we should move to an explicit declaration of capabilites, as modern clients require that (ex. Emacs lsp-mode will not send notifications that are not defined in capabilities, which is correct, imo).