### PR TITLE
Fix undefined method

### DIFF
--- a/pyls/config/source.py
+++ b/pyls/config/source.py
@@ -52,7 +52,7 @@ def _get_opt(config, key, option, opt_type):
             continue
 
         if opt_type == bool:
-            return config.getbool(key, opt_key)
+            return config.getboolean(key, opt_key)
 
         if opt_type == int:
             return config.getint(key, opt_key)


### PR DESCRIPTION
As far as I can tell, this method doesn’t exist in either Python 2 or Python 3, but `getboolean` does.