### PR TITLE
Increase maximum supported version of Jedi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'future>=0.14.0',
         'futures; python_version<"3.2"',
         'backports.functools_lru_cache; python_version<"3.2"',
-        'jedi>=0.13.2,<0.14',
+        'jedi>=0.13.2,<0.15,!=0.14.0',
         'python-jsonrpc-server>=0.1.0',
         'pluggy'
     ],


### PR DESCRIPTION
Now that Jedi 0.14.1 is out, we can support it.

Fixes #606.