### PR TITLE
Adding Docker image for running the pyls server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.6-slim
+# Install pyls
+RUN pip install python-language-server
+# Run the LSP on port 5007
+ENTRYPOINT ["pyls", "--tcp", "--port", "5007", "--host", "0.0.0.0"]


### PR DESCRIPTION
# Docker image for pyls
This will enable running pyls (tcp mode) for dev, testing and prod in the same environment.

This currently uses the pyls version available on pip, but we can extend it to have the nightly version for testing and developing on the last version.
