### PR TITLE
Update requirements use to Jedi 0.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'future>=0.14.0',
         'futures; python_version<"3.2"',
         'backports.functools_lru_cache; python_version<"3.2"',
-        'jedi>=0.13.2,<0.15,!=0.14.0',
+        'jedi>=0.13.2,<0.16,!=0.14.0',
         'python-jsonrpc-server>=0.1.0',
         'pluggy'
     ],


### PR DESCRIPTION
From https://github.com/davidhalter/jedi/blob/master/CHANGELOG.rst jedi 0.15 doesn't look like it did any backwards incompatible changes.