### PR TITLE
Add release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+To release a new version of the PyLS you need to follow these steps:
+
+* Close the current milestone on Github
+
+* git pull or git fetch/merge
+
+* git tag -a X.X.X -m 'Release X.X.X'
+
+* git push upstream --tags
+
+* Publish release in our Github Releases page


### PR DESCRIPTION
This is a simple set of instructions for maintainers to remember what to do to release a new version of the PyLS.