### PR TITLE
Enable parent process checking for TCP server

### DIFF
--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -55,10 +55,12 @@ def main():
     _configure_logger(args.verbose, args.log_config, args.log_file)
 
     if args.tcp:
-        start_tcp_lang_server(args.host, args.port, PythonLanguageServer)
+        start_tcp_lang_server(args.host, args.port, args.check_parent_process,
+                              PythonLanguageServer)
     else:
         stdin, stdout = _binary_stdio()
-        start_io_lang_server(stdin, stdout, args.check_parent_process, PythonLanguageServer)
+        start_io_lang_server(stdin, stdout, args.check_parent_process,
+                             PythonLanguageServer)
 
 
 def _binary_stdio():

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -36,8 +36,7 @@ class _StreamHandlerWrapper(socketserver.StreamRequestHandler, object):
         self.delegate.start()
 
 
-def start_tcp_lang_server(bind_addr, port, check_parent_process,
-                          handler_class):
+def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class):
     if not issubclass(handler_class, PythonLanguageServer):
         raise ValueError('Handler class must be an instance of PythonLanguageServer')
 


### PR DESCRIPTION
Allow to shutdown pyls if TCP mode is active and the parent process reported by the ```$/initialized``` call is killed.