### PR TITLE
Don't limit jedi to <0.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'future>=0.14.0',
         'futures; python_version<"3.2"',
         'backports.functools_lru_cache; python_version<"3.2"',
-        'jedi>=0.14.1,<0.15',
+        'jedi>=0.14.1',
         'python-jsonrpc-server>=0.1.0',
         'pluggy'
     ],


### PR DESCRIPTION
Tests pass without failure (82 passed, 5 skipped), and it improves my life (a Linux Python maintainer) so I use system jedi in openSUSE. I will create the system package of pyls.