### PR TITLE
Shutdown TCP ServerSocket when parent process ends

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,8 @@ install:
 test_script:
   - "%PYTHON%/Scripts/pytest.exe test/"
 
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# on_finish:
+#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 build: false  # Not a C# project
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
 environment:
+  global:
+    APPVEYOR_RDP_PASSWORD: "dcca4c4863E30d56c2e0dda6327370b3#"
   matrix:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.15"
@@ -20,6 +22,9 @@ install:
 
 test_script:
   - "%PYTHON%/Scripts/pytest.exe test/"
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 build: false  # Not a C# project
 

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -152,7 +152,7 @@ def interrupt_process(pid=None):
         pid = os.getpid()
     sig = signal.SIGINT
     if os.name == 'nt':
-        sig = signal.CTRL_C_EVENT
+        sig = signal.CTRL_C_EVENT  # pylint: disable=no-member
     os.kill(pid, sig)
 
 

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -4,7 +4,6 @@ import inspect
 import logging
 import os
 import sys
-import signal
 import threading
 
 PY2 = sys.version_info.major == 2
@@ -145,15 +144,6 @@ def clip_column(column, lines, line_number):
     # https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#position
     max_column = len(lines[line_number].rstrip('\r\n')) if len(lines) > line_number else 0
     return min(column, max_column)
-
-
-def interrupt_process(pid=None):
-    if pid is None:
-        pid = os.getpid()
-    sig = signal.SIGINT
-    if os.name == 'nt':
-        sig = signal.CTRL_C_EVENT  # pylint: disable=no-member
-    os.kill(pid, sig)
 
 
 if os.name == 'nt':

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import os
 import sys
+import signal
 import threading
 
 PY2 = sys.version_info.major == 2
@@ -144,6 +145,15 @@ def clip_column(column, lines, line_number):
     # https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#position
     max_column = len(lines[line_number].rstrip('\r\n')) if len(lines) > line_number else 0
     return min(column, max_column)
+
+
+def interrupt_process(pid=None):
+    if pid is None:
+        pid = os.getpid()
+    sig = signal.SIGINT
+    if os.name == 'nt':
+        sig = signal.CTRL_C_EVENT
+    os.kill(pid, sig)
 
 
 if os.name == 'nt':

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -205,7 +205,6 @@ class PythonLanguageServer(MethodDispatcher):
                     log.info("parent process %s is not alive", pid)
                     self.m_exit()
                 else:
-                    log.debug("parent process %s is still alive", pid)
                     threading.Timer(PARENT_PROCESS_WATCH_INTERVAL, watch_parent_process, args=[pid]).start()
 
             self.watching_thread = threading.Thread(target=watch_parent_process, args=(processId,))

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -45,6 +45,7 @@ def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class):
         handler_class.__name__ + 'Handler',
         (_StreamHandlerWrapper,),
         {'DELEGATE_CLASS': partial(handler_class,
+                                   is_tcp=True,
                                    check_parent_process=check_parent_process)}
     )
 
@@ -74,7 +75,7 @@ class PythonLanguageServer(MethodDispatcher):
 
     # pylint: disable=too-many-public-methods,redefined-builtin
 
-    def __init__(self, rx, tx, check_parent_process=False):
+    def __init__(self, rx, tx, is_tcp=False, check_parent_process=False):
         self.workspace = None
         self.config = None
         self.root_uri = None
@@ -85,6 +86,7 @@ class PythonLanguageServer(MethodDispatcher):
         self._jsonrpc_stream_reader = JsonRpcStreamReader(rx)
         self._jsonrpc_stream_writer = JsonRpcStreamWriter(tx)
         self._check_parent_process = check_parent_process
+        self._is_tcp = is_tcp
         self._endpoint = Endpoint(self, self._jsonrpc_stream_writer.write, max_workers=MAX_WORKERS)
         self._dispatchers = []
         self._shutdown = False
@@ -121,7 +123,7 @@ class PythonLanguageServer(MethodDispatcher):
         self._jsonrpc_stream_reader.close()
         self._jsonrpc_stream_writer.close()
 
-        if self._check_parent_process:
+        if self._is_tcp and self._check_parent_process:
             _utils.interrupt_process()
 
     def _match_uri_to_workspace(self, uri):

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -34,6 +34,7 @@ class _StreamHandlerWrapper(socketserver.StreamRequestHandler, object):
 
     def handle(self):
         self.delegate.start()
+        # pylint: disable=no-member
         self.SHUTDOWN_CALL()
 
 
@@ -42,6 +43,7 @@ def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class):
         raise ValueError('Handler class must be an instance of PythonLanguageServer')
 
     def shutdown_server(*args):
+        # pylint: disable=unused-argument
         log.debug('Shutting down server')
         # Shutdown call must be done on a thread, to prevent deadlocks
         stop_thread = threading.Thread(target=server.shutdown)

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -206,7 +206,6 @@ class PythonLanguageServer(MethodDispatcher):
             self.watching_thread = threading.Thread(target=watch_parent_process, args=(processId,))
             self.watching_thread.daemon = True
             self.watching_thread.start()
-
         # Get our capabilities
         return {'capabilities': self.capabilities()}
 

--- a/test/test_language_server.py
+++ b/test/test_language_server.py
@@ -25,7 +25,9 @@ class _ClientServer(object):
         # Server to client pipe
         scr, scw = os.pipe()
 
-        self.process = multiprocessing.Process(target=start_io_lang_server, args=(
+        ParallelKind = multiprocessing.Process if os.name != 'nt' else Thread
+
+        self.process = ParallelKind(target=start_io_lang_server, args=(
             os.fdopen(csr, 'rb'), os.fdopen(scw, 'wb'), check_parent_process, PythonLanguageServer
         ))
         self.process.start()

--- a/test/test_language_server.py
+++ b/test/test_language_server.py
@@ -1,5 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import os
+import time
+import multiprocessing
 from threading import Thread
 
 from test import unix_only
@@ -8,7 +10,7 @@ import pytest
 
 from pyls.python_ls import start_io_lang_server, PythonLanguageServer
 
-CALL_TIMEOUT = 2
+CALL_TIMEOUT = 10
 
 
 def start_client(client):
@@ -23,11 +25,10 @@ class _ClientServer(object):
         # Server to client pipe
         scr, scw = os.pipe()
 
-        self.server_thread = Thread(target=start_io_lang_server, args=(
+        self.process = multiprocessing.Process(target=start_io_lang_server, args=(
             os.fdopen(csr, 'rb'), os.fdopen(scw, 'wb'), check_parent_process, PythonLanguageServer
         ))
-        self.server_thread.daemon = True
-        self.server_thread.start()
+        self.process.start()
 
         self.client = PythonLanguageServer(os.fdopen(scr, 'rb'), os.fdopen(csw, 'wb'), start_io_lang_server)
         self.client_thread = Thread(target=start_client, args=[self.client])
@@ -56,9 +57,10 @@ def client_exited_server():
     """
     client_server_pair = _ClientServer(True)
 
-    yield client_server_pair.client
+    # yield client_server_pair.client
+    return client_server_pair
 
-    assert client_server_pair.server_thread.is_alive() is False
+    assert client_server_pair.process.is_alive() is False
 
 
 def test_initialize(client_server):  # pylint: disable=redefined-outer-name
@@ -72,12 +74,17 @@ def test_initialize(client_server):  # pylint: disable=redefined-outer-name
 @unix_only
 def test_exit_with_parent_process_died(client_exited_server):  # pylint: disable=redefined-outer-name
     # language server should have already exited before responding
-    with pytest.raises(Exception):
-        client_exited_server._endpoint.request('initialize', {
-            'processId': 1234,
-            'rootPath': os.path.dirname(__file__),
-            'initializationOptions': {}
-        }).result(timeout=CALL_TIMEOUT)
+    lsp_server, mock_process = client_exited_server.client, client_exited_server.process
+    # with pytest.raises(Exception):
+    lsp_server._endpoint.request('initialize', {
+        'processId': mock_process.pid,
+        'rootPath': os.path.dirname(__file__),
+        'initializationOptions': {}
+    }).result(timeout=CALL_TIMEOUT)
+
+    mock_process.terminate()
+    time.sleep(CALL_TIMEOUT)
+    assert not client_exited_server.client_thread.is_alive()
 
 
 def test_not_exit_without_check_parent_process_flag(client_server):  # pylint: disable=redefined-outer-name

--- a/test/test_language_server.py
+++ b/test/test_language_server.py
@@ -58,7 +58,7 @@ def client_exited_server():
     client_server_pair = _ClientServer(True)
 
     # yield client_server_pair.client
-    return client_server_pair
+    yield client_server_pair
 
     assert client_server_pair.process.is_alive() is False
 


### PR DESCRIPTION
This PR enables to interrupt actual TCP server when parent server ends, as the current behaviour only closes the communication channel