### PR TITLE
Flake8 plugin for linting

### DIFF
--- a/pyls/config/flake8_conf.py
+++ b/pyls/config/flake8_conf.py
@@ -19,6 +19,13 @@ OPTIONS = [
     ('ignore', 'plugins.pycodestyle.ignore', list),
     ('max-line-length', 'plugins.pycodestyle.maxLineLength', int),
     ('select', 'plugins.pycodestyle.select', list),
+    # flake8
+    ('exclude', 'plugins.flake8.exclude', list),
+    ('filename', 'plugins.flake8.filename', list),
+    ('hang-closing', 'plugins.flake8.hangClosing', bool),
+    ('ignore', 'plugins.flake8.ignore', list),
+    ('max-line-length', 'plugins.flake8.maxLineLength', int),
+    ('select', 'plugins.flake8.select', list),
 ]
 
 

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -1,0 +1,61 @@
+# Copyright 2017 Palantir Technologies, Inc.
+import logging
+from flake8.api import legacy as flake8
+from pyls import hookimpl, lsp
+
+log = logging.getLogger(__name__)
+
+
+@hookimpl
+def pyls_lint(config, document):
+    settings = config.plugin_settings('flake8')
+    log.debug("Got flake8 settings: %s", settings)
+
+    opts = {
+        'exclude': settings.get('exclude'),
+        'filename': settings.get('filename'),
+        'hang_closing': settings.get('hangClosing'),
+        'ignore': settings.get('ignore'),
+        'max_line_length': settings.get('maxLineLength'),
+        'select': settings.get('select'),
+    }
+
+    kwargs = {k: v for k, v in opts.items() if v}
+    style_guide = flake8.get_style_guide(quiet=4, verbose=0, **kwargs)
+
+    report = style_guide.check_files([document.path])
+    diagnostics = parse_report(document, report)
+
+    return diagnostics
+
+
+def parse_report(document, report):
+    file_checkers = report._application.file_checker_manager.checkers
+    # There should be only one filechecker since we are parsing using a path and not a pattern
+    if len(file_checkers) > 1:
+        log.error("Flake8 parsed more than a file for '%s'", document.path)
+
+    diagnostics = []
+    file_checker = file_checkers[0]
+    for error in file_checker.results:
+        code, line, character, msg, physical_line = error
+        diagnostics.append(
+            {
+                'source': 'flake8',
+                'code': code,
+                'range': {
+                    'start': {
+                        'line': line,
+                        'character': character
+                    },
+                    'end': {
+                        'line': line,
+                        'character': len(physical_line)
+                    }
+                },
+                'message': msg,
+                'severity': lsp.DiagnosticSeverity.Warning,
+            }
+        )
+
+    return diagnostics

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Palantir Technologies, Inc.
+# Copyright 2019 Palantir Technologies, Inc.
 import logging
 from flake8.api import legacy as flake8
 from pyls import hookimpl, lsp
@@ -31,7 +31,7 @@ def pyls_lint(config, document):
 
 def parse_report(document, report):
     file_checkers = report._application.file_checker_manager.checkers
-    # There should be only one filechecker since we are parsing using a path and not a pattern
+    # There should be only a filechecker since we are parsing using a path and not a pattern
     if len(file_checkers) > 1:
         log.error("Flake8 parsed more than a file for '%s'", document.path)
 

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Palantir Technologies, Inc.
+"""Linter pluging for flake8"""
 import logging
 from flake8.api import legacy as flake8
 from pyls import hookimpl, lsp
@@ -29,6 +30,9 @@ def pyls_lint(config, document):
 
 def parse_report(document, report):
     file_checkers = report._application.file_checker_manager.checkers
+    # No file have been checked
+    if not file_checkers:
+        return []
     # There should be only a filechecker since we are parsing using a path and not a pattern
     if len(file_checkers) > 1:
         log.error("Flake8 parsed more than a file for '%s'", document.path)

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -22,11 +22,9 @@ def pyls_lint(config, document):
 
     kwargs = {k: v for k, v in opts.items() if v}
     style_guide = flake8.get_style_guide(quiet=4, verbose=0, **kwargs)
-
     report = style_guide.check_files([document.path])
-    diagnostics = parse_report(document, report)
 
-    return diagnostics
+    return parse_report(document, report)
 
 
 def parse_report(document, report):

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -8,6 +8,12 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl
+def pyls_settings():
+    # Default flake8 to disabled
+    return {'plugins': {'flake8': {'enabled': False}}}
+
+
+@hookimpl
 def pyls_lint(config, document):
     settings = config.plugin_settings('flake8')
     log.debug("Got flake8 settings: %s", settings)

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -80,6 +80,7 @@ def parse_report(document, report):
                     },
                     'end': {
                         'line': line,
+                        # no way to determine the column
                         'character': len(physical_line)
                     }
                 },

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         ],
         'pyls': [
             'autopep8 = pyls.plugins.autopep8_format',
+            'flake8 = pyls.plugins.flake8_lint',
             'jedi_completion = pyls.plugins.jedi_completion',
             'jedi_definition = pyls.plugins.definition',
             'jedi_hover = pyls.plugins.hover',

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     extras_require={
         'all': [
             'autopep8',
+            'flake8==3.7.8',
             'mccabe',
             'pycodestyle',
             'pydocstyle>=2.0.0',
@@ -57,6 +58,7 @@ setup(
             'yapf',
         ],
         'autopep8': ['autopep8'],
+        'flake8': ['flake8==3.7.8'],
         'mccabe': ['mccabe'],
         'pycodestyle': ['pycodestyle'],
         'pydocstyle': ['pydocstyle>=2.0.0'],

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     extras_require={
         'all': [
             'autopep8',
-            'flake8==3.7.8',
+            'flake8',
             'mccabe',
             'pycodestyle',
             'pydocstyle>=2.0.0',
@@ -58,7 +58,7 @@ setup(
             'yapf',
         ],
         'autopep8': ['autopep8'],
-        'flake8': ['flake8==3.7.8'],
+        'flake8': ['flake8'],
         'mccabe': ['mccabe'],
         'pycodestyle': ['pycodestyle'],
         'pydocstyle': ['pydocstyle>=2.0.0'],

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -1,0 +1,53 @@
+# Copyright 2019 Palantir Technologies, Inc.
+import tempfile
+import os
+from pyls import lsp, uris
+from pyls.plugins import flake8_lint
+from pyls.workspace import Document
+
+DOC_URI = uris.from_fs_path(__file__)
+DOC = """import pyls
+
+t = "TEST"
+
+def using_const():
+\ta = 8 + 9
+\treturn t
+"""
+
+
+def temp_document(doc_text):
+    temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    name = temp_file.name
+    temp_file.write(doc_text)
+    temp_file.close()
+    doc = Document(uris.from_fs_path(name))
+
+    return name, doc
+
+
+
+def test_flake8_no_checked_file(config):
+    # A bad uri or a non-saved file may cause the flake8 linter to do nothing.
+    # In this situtation, the linter will return an empty list.
+
+    doc = Document('', DOC)
+    diags = flake8_lint.pyls_lint(config, doc)
+    assert diags == []
+
+
+def test_flake8_lintin(config):
+    try:
+        name, doc = temp_document(DOC)
+        diags = flake8_lint.pyls_lint(config, doc)
+        msg = 'local variable \'a\' is assigned to but never used'
+        unused_var = [d for d in diags if d['message'] == msg][0]
+
+        assert unused_var['source'] == 'flake8'
+        assert unused_var['code'] == 'F841'
+        assert unused_var['range']['start'] == {'line': 6, 'character': 1}
+        assert unused_var['range']['end'] == {'line': 6, 'character': 11}
+        assert unused_var['severity'] == lsp.DiagnosticSeverity.Warning
+
+    finally:
+        os.remove(name)

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -26,7 +26,6 @@ def temp_document(doc_text):
     return name, doc
 
 
-
 def test_flake8_no_checked_file(config):
     # A bad uri or a non-saved file may cause the flake8 linter to do nothing.
     # In this situtation, the linter will return an empty list.
@@ -36,7 +35,7 @@ def test_flake8_no_checked_file(config):
     assert diags == []
 
 
-def test_flake8_lintin(config):
+def test_flake8_lint(config):
     try:
         name, doc = temp_document(DOC)
         diags = flake8_lint.pyls_lint(config, doc)


### PR DESCRIPTION
As per the discussion here #190 a way of supporting flake8 linting is by implementing an additional plugin that will use the flake8 config directly instead of passing it to other linting tools like pycodestyle and pyflakes (even if flake8 is a wrapper around those tools by itself).

Flake8 lacks (for now) of a stable [public python API](http://flake8.pycqa.org/en/latest/user/python-api.html) which should be implemented in the future, so I figured out a dirty way from the source code to access the report results and get the information we need to report back to the IDE, however, this should be updated whenever a python API is made available.