### PR TITLE
If client declares supports, provide snippet completions by default

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -49,7 +49,7 @@ def pyls_completions(config, document, position):
     snippet_support = completion_capabilities.get('completionItem', {}).get('snippetSupport')
 
     settings = config.plugin_settings('jedi_completion', document_path=document.path)
-    should_include_params = settings.get('include_params')
+    should_include_params = settings.get('include_params', True)
 
     return [_format_completion(d, snippet_support and should_include_params) for d in definitions] or None
 


### PR DESCRIPTION
This is the way python-language-server used to work before #519.  This
shouldn't conflict with the goals of #515 of #526, i.e. if the client
does _not_ declare support for snippets, none are sent.

* pyls/plugins/jedi_completion.py (pyls_completions): Default
should_include_params to True, like before.