### PR TITLE
Language server line numbers are zero-indexed

### DIFF
--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -81,11 +81,11 @@ def parse_report(document, report):
                 'code': code,
                 'range': {
                     'start': {
-                        'line': line,
+                        'line': line - 1,
                         'character': character
                     },
                     'end': {
-                        'line': line,
+                        'line': line - 1,
                         # no way to determine the column
                         'character': len(physical_line)
                     }

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -44,8 +44,8 @@ def test_flake8_lint(config):
 
         assert unused_var['source'] == 'flake8'
         assert unused_var['code'] == 'F841'
-        assert unused_var['range']['start'] == {'line': 6, 'character': 1}
-        assert unused_var['range']['end'] == {'line': 6, 'character': 11}
+        assert unused_var['range']['start'] == {'line': 5, 'character': 1}
+        assert unused_var['range']['end'] == {'line': 5, 'character': 11}
         assert unused_var['severity'] == lsp.DiagnosticSeverity.Warning
 
     finally:


### PR DESCRIPTION
But flake8 gives one-indexed line numbers.

So all the diagnostics from the new flake8 linter were on the wrong line.

Unexpectedly (to me at least) the columns seem to be correct.  Apparently flake8 returns 1-indexed line numbers and 0-indexed column numbers.  Yay consistency.