### PR TITLE
Only use future library in Python 2

### DIFF
--- a/pyls/__init__.py
+++ b/pyls/__init__.py
@@ -1,10 +1,13 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import os
-from future.standard_library import install_aliases
+import sys
 import pluggy
 from ._version import get_versions
 
-install_aliases()
+if sys.version_info[0] < 3:
+    from future.standard_library import install_aliases
+    install_aliases()
+
 __version__ = get_versions()['version']
 del get_versions
 

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'configparser; python_version<"3.0"',
-        'future>=0.14.0',
-        'futures; python_version<"3.2"',
+        'future>=0.14.0; python_version<"3"',
         'backports.functools_lru_cache; python_version<"3.2"',
         'jedi>=0.15.0,<0.16',
         'python-jsonrpc-server>=0.1.0',


### PR DESCRIPTION
- install future only if python2
- remove futures which is not used any more