### PR TITLE
Use flake8 utility instead of its internal API

### DIFF
--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -98,8 +98,9 @@ def parse_stdout(document, stdout):
     """
 
     diagnostics = []
-    parsed_lines = re.findall(r'(.*):(\d*):(\d*): (\w*) (.*)', stdout)
-    for parsed_line in parsed_lines:
+    lines = stdout.splitlines()
+    for raw_line in lines:
+        parsed_line = re.findall(r'(.*):(\d*):(\d*): (\w*) (.*)', raw_line)
         if not parsed_line:
             continue
         _, line, character, code, msg = parsed_line

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -101,7 +101,8 @@ def parse_stdout(document, stdout):
     lines = stdout.splitlines()
     for raw_line in lines:
         parsed_line = re.findall(r'(.*):(\d*):(\d*): (\w*) (.*)', raw_line)
-        if not parsed_line:
+        if not parsed_line or len(parsed_line) != 5:
+            log.debug("Flake8 output parser can't parse line '%s'", raw_line)
             continue
         _, line, character, code, msg = parsed_line
         line = int(line) - 1

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -100,7 +100,7 @@ def parse_stdout(document, stdout):
     diagnostics = []
     lines = stdout.splitlines()
     for raw_line in lines:
-        parsed_line = re.findall(r'(.*):(\d*):(\d*): (\w*) (.*)', raw_line)
+        parsed_line = re.match(r'(.*):(\d*):(\d*): (\w*) (.*)', raw_line).groups()
         if not parsed_line or len(parsed_line) != 5:
             log.debug("Flake8 output parser can't parse line '%s'", raw_line)
             continue

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -39,7 +39,15 @@ def run_flake8(args):
     from stderr if any.
     """
     log.debug("Calling flake8 with args: '%s'", args)
-    p = Popen(args, stdout=PIPE, stderr=PIPE)
+    try:
+        cmd = ['flake8']
+        cmd.extend(args)
+        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+    except:
+        log.debug("Can't execute flake8. Trying with 'python -m flake8'")
+        cmd = ['python', '-m', 'flake8']
+        cmd.extend(args)
+        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
     stderr = p.stderr.read().decode()
     if stderr:
         log.error("Error while running flake8 '%s'", stderr)
@@ -54,7 +62,7 @@ def build_args(options, doc_path):
         options: dictionary of argument names and their values.
         doc_path: path of the document to lint.
     """
-    args = ['flake8', doc_path]
+    args = [doc_path]
     for arg_name, arg_val in options.items():
         arg = None
         if isinstance(arg_val, list):

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -1,7 +1,8 @@
 # Copyright 2019 Palantir Technologies, Inc.
 """Linter pluging for flake8"""
 import logging
-from flake8.api import legacy as flake8
+import re
+from subprocess import Popen, PIPE
 from pyls import hookimpl, lsp
 
 log = logging.getLogger(__name__)
@@ -21,23 +22,56 @@ def pyls_lint(config, document):
     opts = {
         'exclude': settings.get('exclude'),
         'filename': settings.get('filename'),
-        'hang_closing': settings.get('hangClosing'),
+        'hang-closing': settings.get('hangClosing'),
         'ignore': settings.get('ignore'),
-        'max_line_length': settings.get('maxLineLength'),
+        'max-line-length': settings.get('maxLineLength'),
         'select': settings.get('select'),
     }
 
-    # Build the flake8 checker and use it to generate a report from the document
-    kwargs = {k: v for k, v in opts.items() if v}
-    style_guide = flake8.get_style_guide(quiet=4, verbose=0, **kwargs)
-    report = style_guide.check_files([document.path])
-
-    return parse_report(document, report)
+    # Call the flake8 utility then parse diagnostics from stdout
+    args = build_args(opts, document.path)
+    output = run_flake8(args)
+    return parse_stdout(document, output)
 
 
-def parse_report(document, report):
+def run_flake8(args):
+    """Run flake8 with the provided arguments, logs errors
+    from stderr if any.
     """
-    Build a diagnostics from a report, it should extract every result and format
+    log.debug("Calling flake8 with args: '%s'", args)
+    p = Popen(args, stdout=PIPE, stderr=PIPE)
+    stderr = p.stderr.read().decode()
+    if stderr:
+        log.error("Error while running flake8 '%s'", stderr)
+    stdout = p.stdout
+    return stdout.read().decode()
+
+
+def build_args(options, doc_path):
+    """Build arguments for calling flake8.
+
+    Args:
+        options: dictionary of argument names and their values.
+        doc_path: path of the document to lint.
+    """
+    args = ['flake8', doc_path]
+    for arg_name, arg_val in options.items():
+        arg = None
+        if isinstance(arg_val, list):
+            arg = '--{}={}'.format(arg_name, ','.join(arg_val))
+        elif isinstance(arg_val, bool):
+            if arg_val:
+                arg = '--{}'.format(arg_name)
+        elif isinstance(arg_val, int):
+            arg = '--{}={}'.format(arg_name, arg_val)
+        if arg:
+            args.append(arg)
+    return args
+
+
+def parse_stdout(document, stdout):
+    """
+    Build a diagnostics from flake8's output, it should extract every result and format
     it into a dict that looks like this:
         {
             'source': 'flake8',
@@ -58,40 +92,37 @@ def parse_report(document, report):
 
     Args:
         document: The document to be linted.
-        report: A Report object returned by checking the document.
+        stdout: output from flake8
     Returns:
         A list of dictionaries.
     """
 
-    file_checkers = report._application.file_checker_manager.checkers
-    # No file have been checked
-    if not file_checkers:
-        return []
-    # There should be only a filechecker since we are parsing using a path and not a pattern
-    if len(file_checkers) > 1:
-        log.error("Flake8 parsed more than a file for '%s'", document.path)
-
     diagnostics = []
-    file_checker = file_checkers[0]
-    for error in file_checker.results:
-        code, line, character, msg, physical_line = error
+    parsed_lines = re.findall(r'(.*):(\d*):(\d*): (\w*) (.*)', stdout)
+    log.debug("doc %s", document.lines)
+    log.debug(dir(document))
+    for parsed_line in parsed_lines:
+        if not parsed_line:
+            continue
+        _, line, character, code, msg = parsed_line
+        line = int(line) - 1
+        character = int(character) - 1
         diagnostics.append(
             {
                 'source': 'flake8',
                 'code': code,
                 'range': {
                     'start': {
-                        'line': line - 1,
+                        'line': line,
                         'character': character
                     },
                     'end': {
-                        'line': line - 1,
+                        'line': line,
                         # no way to determine the column
-                        'character': len(physical_line)
+                        'character': len(document.lines[line])
                     }
                 },
                 'message': msg,
-                # no way to determine the severity using the legacy api
                 'severity': lsp.DiagnosticSeverity.Warning,
             }
         )

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -99,8 +99,6 @@ def parse_stdout(document, stdout):
 
     diagnostics = []
     parsed_lines = re.findall(r'(.*):(\d*):(\d*): (\w*) (.*)', stdout)
-    log.debug("doc %s", document.lines)
-    log.debug(dir(document))
     for parsed_line in parsed_lines:
         if not parsed_line:
             continue

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -43,7 +43,7 @@ def run_flake8(args):
         cmd = ['flake8']
         cmd.extend(args)
         p = Popen(cmd, stdout=PIPE, stderr=PIPE)
-    except:
+    except IOError:
         log.debug("Can't execute flake8. Trying with 'python -m flake8'")
         cmd = ['python', '-m', 'flake8']
         cmd.extend(args)

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -1,13 +1,9 @@
 # Copyright 2019 Palantir Technologies, Inc.
 import tempfile
 import os
-import logging
 from pyls import lsp, uris
 from pyls.plugins import flake8_lint
 from pyls.workspace import Document
-
-
-log = logging.getLogger(__name__)
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """import pyls
@@ -43,7 +39,6 @@ def test_flake8_lint(config):
     try:
         name, doc = temp_document(DOC)
         diags = flake8_lint.pyls_lint(config, doc)
-        log.debug('diags from flake8 test %s', diags)
         msg = 'local variable \'a\' is assigned to but never used'
         unused_var = [d for d in diags if d['message'] == msg][0]
 

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -1,9 +1,13 @@
 # Copyright 2019 Palantir Technologies, Inc.
 import tempfile
 import os
+import logging
 from pyls import lsp, uris
 from pyls.plugins import flake8_lint
 from pyls.workspace import Document
+
+
+log = logging.getLogger(__name__)
 
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """import pyls
@@ -39,6 +43,7 @@ def test_flake8_lint(config):
     try:
         name, doc = temp_document(DOC)
         diags = flake8_lint.pyls_lint(config, doc)
+        log.debug('diags from flake8 test %s', diags)
         msg = 'local variable \'a\' is assigned to but never used'
         unused_var = [d for d in diags if d['message'] == msg][0]
 


### PR DESCRIPTION
The usage of the internal API doesn't seem to work so well as the reports returned doesn't ignore the codes passed as arguments #676 . 

A solution around this was to re-implement flake8 linting via its utility.

Fixes #676.