### PR TITLE
Add Jedi support for extra paths and different environment handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
       - image: "python:3.5-stretch"
     steps:
       - checkout
+      # To test Jedi environments
+      - run: python3 -m venv /tmp/pyenv
+      - run: /tmp/pyenv/bin/python -m pip install loghub
       - run: pip install -e .[all] .[test]
       - run: py.test -v test/
 

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -42,10 +42,7 @@ _TYPE_MAP = {
 @hookimpl
 def pyls_completions(config, document, position):
     settings = config.plugin_settings('jedi_completion', document_path=document.path)
-    environment = settings.get('environment')
-    extra_paths = settings.get('extra_paths')
-    definitions = document.jedi_script(position, extra_paths=extra_paths,
-                                       environment=environment).completions()
+    definitions = document.jedi_script(position).completions()
     if not definitions:
         return None
 

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -41,7 +41,6 @@ _TYPE_MAP = {
 
 @hookimpl
 def pyls_completions(config, document, position):
-    settings = config.plugin_settings('jedi_completion', document_path=document.path)
     definitions = document.jedi_script(position).completions()
     if not definitions:
         return None
@@ -49,6 +48,7 @@ def pyls_completions(config, document, position):
     completion_capabilities = config.capabilities.get('textDocument', {}).get('completion', {})
     snippet_support = completion_capabilities.get('completionItem', {}).get('snippetSupport')
 
+    settings = config.plugin_settings('jedi_completion', document_path=document.path)
     should_include_params = settings.get('include_params')
 
     return [_format_completion(d, snippet_support and should_include_params) for d in definitions] or None

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -41,14 +41,17 @@ _TYPE_MAP = {
 
 @hookimpl
 def pyls_completions(config, document, position):
-    definitions = document.jedi_script(position).completions()
+    settings = config.plugin_settings('jedi_completion', document_path=document.path)
+    environment = settings.get('environment')
+    extra_paths = settings.get('extra_paths')
+    definitions = document.jedi_script(position, extra_paths=extra_paths,
+                                       environment=environment).completions()
     if not definitions:
         return None
 
     completion_capabilities = config.capabilities.get('textDocument', {}).get('completion', {})
     snippet_support = completion_capabilities.get('completionItem', {}).get('snippetSupport')
 
-    settings = config.plugin_settings('jedi_completion', document_path=document.path)
     should_include_params = settings.get('include_params')
 
     return [_format_completion(d, snippet_support and should_include_params) for d in definitions] or None

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -62,6 +62,7 @@ def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class):
     server.allow_reuse_address = True
 
     try:
+        log.info('WHAT WHAT!')
         log.info('Serving %s on (%s, %s)', handler_class.__name__, bind_addr, port)
         server.serve_forever()
     finally:

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -61,7 +61,6 @@ def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class):
     server = socketserver.TCPServer((bind_addr, port), wrapper_class)
     server.allow_reuse_address = True
 
-
     try:
         log.info('Serving %s on (%s, %s)', handler_class.__name__, bind_addr, port)
         server.serve_forever()

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -61,8 +61,8 @@ def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class):
     server = socketserver.TCPServer((bind_addr, port), wrapper_class)
     server.allow_reuse_address = True
 
+
     try:
-        log.info('WHAT WHAT!')
         log.info('Serving %s on (%s, %s)', handler_class.__name__, bind_addr, port)
         server.serve_forever()
     finally:
@@ -312,7 +312,7 @@ class PythonLanguageServer(MethodDispatcher):
         return self.highlight(textDocument['uri'], position)
 
     def m_text_document__hover(self, textDocument=None, position=None, **_kwargs):
-        return self.hover(config, textDocument['uri'], position)
+        return self.hover(textDocument['uri'], position)
 
     def m_text_document__document_symbol(self, textDocument=None, **_kwargs):
         return self.document_symbols(textDocument['uri'])
@@ -341,7 +341,6 @@ class PythonLanguageServer(MethodDispatcher):
             workspace = self.workspaces[workspace_uri]
             workspace.update_config(self.config)
             for doc_uri in workspace.documents:
-                workspace.get_document(doc_uri).update_config(self.config)
                 self.lint(doc_uri, is_saved=False)
 
     def m_workspace__did_change_workspace_folders(self, added=None, removed=None, **_kwargs):

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -84,7 +84,7 @@ class Workspace(object):
     def update_config(self, config):
         self._config = config
         for doc_uri in self.documents:
-            self.get_document(doc_uri).update_config(self.config)
+            self.get_document(doc_uri).update_config(config)
 
     def apply_edit(self, edit):
         return self._endpoint.request(self.M_APPLY_EDIT, {'edit': edit})
@@ -112,7 +112,8 @@ class Workspace(object):
 
 class Document(object):
 
-    def __init__(self, uri, source=None, version=None, local=True, extra_sys_path=None, rope_project_builder=None, config=None, workspace=None):
+    def __init__(self, uri, source=None, version=None, local=True, extra_sys_path=None, rope_project_builder=None,
+                 config=None, workspace=None):
         self.uri = uri
         self.version = version
         self.path = uris.to_fs_path(uri)
@@ -251,7 +252,7 @@ class Document(object):
             environment = jedi.api.environment.get_cached_default_environment()
         else:
             if environment_path in self._workspace._environments:
-                environment = self._environments[environment_path]
+                environment = self._workspace._environments[environment_path]
             else:
                 environment = jedi.api.environment.create_environment(path=environment_path, safe=True)
                 self._workspace._environments[environment_path] = environment

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -243,9 +243,6 @@ class Document(object):
             'environment': environment,
         }
 
-        log.debug('JEDI SCRIPT?')
-        log.debug(str(kwargs))
-
         if position:
             kwargs['line'] = position['line'] + 1
             kwargs['column'] = _utils.clip_column(position['character'], self.lines, position['line'])

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -212,11 +212,16 @@ class Document(object):
 
         return m_start[0] + m_end[-1]
 
-    def jedi_names(self, all_scopes=False, definitions=True, references=False, environment=None):
+    def jedi_names(self, all_scopes=False, definitions=True, references=False):
+        environment_path = None
+        if self._config:
+            jedi_settings = self._config.plugin_settings('jedi', document_path=self.path)
+            environment_path = jedi_settings.get('environment')
+        environment = self.get_enviroment(environment_path) if environment_path else None
+
         return jedi.api.names(
             source=self.source, path=self.path, all_scopes=all_scopes,
-            definitions=definitions, references=references,
-            environment=environment,
+            definitions=definitions, references=references, environment=environment,
         )
 
     def jedi_script(self, position=None):

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -44,6 +44,15 @@ print Hello().every
 """
 
 
+class MockWorkspace(object):
+    """Mock workspace used by test_jedi_completion_environment."""
+
+    def __init__(self):
+        self._environments = {}
+        # This is to avoid pyling tests of the variable not being used
+        sys.stdout.write(str(self._environments))
+
+
 def test_rope_import_completion(config, workspace):
     com_position = {'line': 0, 'character': 7}
     doc = Document(DOC_URI, DOC)
@@ -51,8 +60,6 @@ def test_rope_import_completion(config, workspace):
     assert items is None
 
 
-@pytest.mark.skipif(LooseVersion(jedi.__version__) < LooseVersion('0.14.0'),
-                    reason='This test fails with previous versions of jedi')
 def test_jedi_completion(config):
     # Over 'i' in os.path.isabs(...)
     com_position = {'line': 1, 'character': 15}
@@ -239,13 +246,6 @@ foo.s"""
     com_position = {'line': 1, 'character': 5}
     completions = pyls_jedi_completions(config, doc, com_position)
     assert completions[0]['label'] == 'spam()'
-
-
-class MockWorkspace(object):
-
-    def __init__(self):
-        self._environments = {}
-        sys.stdout.write(str(self._environments))
 
 
 @pytest.mark.skipif(PY2 or not LINUX or not CI, reason="tested on linux and python 3 only")

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -3,6 +3,7 @@ from distutils.version import LooseVersion
 import os
 import sys
 
+from test.test_utils import MockWorkspace
 import jedi
 import pytest
 
@@ -10,7 +11,6 @@ from pyls import uris, lsp
 from pyls.workspace import Document
 from pyls.plugins.jedi_completion import pyls_completions as pyls_jedi_completions
 from pyls.plugins.rope_completion import pyls_completions as pyls_rope_completions
-from test.test_utils import MockWorkspace
 
 
 PY2 = sys.version[0] == '2'

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -118,3 +118,16 @@ def test_jedi_method_completion(config):
 
     assert 'insertTextFormat' not in everyone_method
     assert everyone_method['insertText'] == 'everyone'
+
+
+def test_jedi_completion_extra_paths(config):
+    pass
+    # # Over the 'w' in 'print Hello().world'
+    # com_position = {'line': 18, 'character': 15}
+    # doc = Document(DOC_URI, DOC)
+    # completions = pyls_jedi_completions(config, doc, com_position)
+
+    # items = {c['label']: c['sortText'] for c in completions}
+
+    # # Ensure we can complete the 'world' property
+    # assert 'world' in list(items.keys())[0]

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -10,6 +10,7 @@ from pyls import uris, lsp
 from pyls.workspace import Document
 from pyls.plugins.jedi_completion import pyls_completions as pyls_jedi_completions
 from pyls.plugins.rope_completion import pyls_completions as pyls_rope_completions
+from test.test_utils import MockWorkspace
 
 
 PY2 = sys.version[0] == '2'
@@ -18,7 +19,6 @@ CI = os.environ.get('CI')
 LOCATION = os.path.realpath(
     os.path.join(os.getcwd(), os.path.dirname(__file__))
 )
-
 DOC_URI = uris.from_fs_path(__file__)
 DOC = """import os
 print os.path.isabs("/tmp")
@@ -42,15 +42,6 @@ print Hello().world
 
 print Hello().every
 """
-
-
-class MockWorkspace(object):
-    """Mock workspace used by test_jedi_completion_environment."""
-
-    def __init__(self):
-        self._environments = {}
-        # This is to avoid pyling tests of the variable not being used
-        sys.stdout.write(str(self._environments))
 
 
 def test_rope_import_completion(config, workspace):

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -2,13 +2,13 @@
 import os
 import sys
 
+from test.test_utils import MockWorkspace
 import pytest
 
 from pyls import uris
 from pyls.plugins.symbols import pyls_document_symbols
 from pyls.lsp import SymbolKind
 from pyls.workspace import Document
-from test.test_utils import MockWorkspace
 
 
 PY2 = sys.version[0] == '2'
@@ -30,6 +30,7 @@ def main(x):
 
 """
 
+
 def helper_check_symbols_all_scope(symbols):
     # All eight symbols (import sys, a, B, __init__, x, y, main, y)
     assert len(symbols) == 8
@@ -45,7 +46,6 @@ def helper_check_symbols_all_scope(symbols):
 
     # Not going to get too in-depth here else we're just testing Jedi
     assert sym('a')['location']['range']['start'] == {'line': 2, 'character': 0}
-
 
 
 def test_symbols(config):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,20 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import time
 import mock
+import sys
+
 from pyls import _utils
+
+
+class MockWorkspace(object):
+    """Mock workspace used by tests that use jedi environment."""
+
+    def __init__(self):
+        """Mock workspace used by tests that use jedi environment."""
+        self._environments = {}
+
+        # This is to avoid pyling tests of the variable not being used
+        sys.stdout.write(str(self._environments))
 
 
 def test_debounce():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,8 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import time
-import mock
 import sys
+
+import mock
 
 from pyls import _utils
 

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -35,6 +35,16 @@
                     },
                     "uniqueItems": true
                 },
+                "pyls.plugins.jedi.extra_paths": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Define extra paths for jedi.Script."
+                },
+                "pyls.plugins.jedi.environment": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Define environment for jedi.Script and Jedi.names."
+                },
                 "pyls.plugins.jedi_completion.enabled": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
This adds the ability to pass more entries to sys.path or a different Python interpreter to Jedi to get additional or new completions (respectively) for them.