### PR TITLE
Add completion tests for several libraries of the Scientific Python stack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
         'pylint': ['pylint'],
         'rope': ['rope>0.10.5'],
         'yapf': ['yapf'],
-        'test': ['versioneer', 'pylint', 'pytest', 'mock', 'pytest-cov', 'coverage'],
+        'test': ['versioneer', 'pylint', 'pytest', 'mock', 'pytest-cov',
+                 'coverage', 'numpy', 'pandas', 'matplotlib'],
     },
 
     # To provide executable scripts, use entry points in preference to the

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -118,3 +118,33 @@ def test_jedi_method_completion(config):
 
     assert 'insertTextFormat' not in everyone_method
     assert everyone_method['insertText'] == 'everyone'
+
+
+def test_numpy_completions(config):
+    doc_numpy = "import numpy as np; np."
+    com_position = {'line': 0, 'character': len(doc_numpy)}
+    doc = Document(DOC_URI, doc_numpy)
+    items = pyls_jedi_completions(config, doc, com_position)
+
+    assert items
+    assert any(['array' in i['label'] for i in items])
+
+
+def test_pandas_completions(config):
+    doc_pandas = "import pandas as pd; pd."
+    com_position = {'line': 0, 'character': len(doc_pandas)}
+    doc = Document(DOC_URI, doc_pandas)
+    items = pyls_jedi_completions(config, doc, com_position)
+
+    assert items
+    assert any(['DataFrame' in i['label'] for i in items])
+
+
+def test_matplotlib_completions(config):
+    doc_mpl = "import matplotlib.pyplot as plt; plt."
+    com_position = {'line': 0, 'character': len(doc_mpl)}
+    doc = Document(DOC_URI, doc_mpl)
+    items = pyls_jedi_completions(config, doc, com_position)
+
+    assert items
+    assert any(['plot' in i['label'] for i in items])

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -46,7 +46,7 @@ def test_rope_import_completion(config, workspace):
 
 
 @pytest.mark.skipif(LooseVersion(jedi.__version__) < LooseVersion('0.14.0'),
-                    reason='This test fails with previous versions of jedi')
+                    reason='This test fails with previous versions of Jedi')
 def test_jedi_completion(config):
     # Over 'i' in os.path.isabs(...)
     com_position = {'line': 1, 'character': 15}
@@ -120,6 +120,8 @@ def test_jedi_method_completion(config):
     assert everyone_method['insertText'] == 'everyone'
 
 
+@pytest.mark.skipif(LooseVersion('0.15.0') <= LooseVersion(jedi.__version__) < LooseVersion('0.16.0'),
+                    reason='This test fails with Jedi 0.15')
 def test_numpy_completions(config):
     doc_numpy = "import numpy as np; np."
     com_position = {'line': 0, 'character': len(doc_numpy)}
@@ -130,6 +132,8 @@ def test_numpy_completions(config):
     assert any(['array' in i['label'] for i in items])
 
 
+@pytest.mark.skipif(LooseVersion('0.15.0') <= LooseVersion(jedi.__version__) < LooseVersion('0.16.0'),
+                    reason='This test fails with Jedi 0.15')
 def test_pandas_completions(config):
     doc_pandas = "import pandas as pd; pd."
     com_position = {'line': 0, 'character': len(doc_pandas)}


### PR DESCRIPTION
This will allow us to verify that Jedi doesn't break completions for libraries like Numpy, Pandas and Matplotlib (the ones tested here).