### PR TITLE
Support again Jedi 0.14.1

### DIFF
--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -1,4 +1,5 @@
 # Copyright 2017 Palantir Technologies, Inc.
+from distutils.version import LooseVersion
 import functools
 import inspect
 import logging
@@ -6,7 +7,10 @@ import os
 import sys
 import threading
 
+import jedi
+
 PY2 = sys.version_info.major == 2
+JEDI_VERSION = jedi.__version__
 
 if PY2:
     import pathlib2 as pathlib
@@ -136,6 +140,8 @@ def format_docstring(contents):
     """
     contents = contents.replace('\t', u'\u00A0' * 4)
     contents = contents.replace('  ', u'\u00A0' * 2)
+    if LooseVersion(JEDI_VERSION) < LooseVersion('0.15.0'):
+        contents = contents.replace('*', '\\*')
     return contents
 
 

--- a/pyls/plugins/hover.py
+++ b/pyls/plugins/hover.py
@@ -1,5 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
+from distutils.version import LooseVersion
 import logging
+
 from pyls import hookimpl, _utils
 
 log = logging.getLogger(__name__)
@@ -10,26 +12,34 @@ def pyls_hover(document, position):
     definitions = document.jedi_script(position).goto_definitions()
     word = document.word_at_position(position)
 
-    # Find first exact matching definition
-    definition = next((x for x in definitions if x.name == word), None)
+    if LooseVersion(_utils.JEDI_VERSION) >= LooseVersion('0.15.0'):
+        # Find first exact matching definition
+        definition = next((x for x in definitions if x.name == word), None)
 
-    if not definition:
+        if not definition:
+            return {'contents': ''}
+
+        # raw docstring returns only doc, without signature
+        doc = _utils.format_docstring(definition.docstring(raw=True))
+
+        # Find first exact matching signature
+        signature = next((x.to_string() for x in definition.get_signatures() if x.name == word), '')
+
+        contents = []
+        if signature:
+            contents.append({
+                'language': 'python',
+                'value': signature,
+            })
+        if doc:
+            contents.append(doc)
+        if not contents:
+            return {'contents': ''}
+        return {'contents': contents}
+    else:
+        # Find an exact match for a completion
+        for d in definitions:
+            if d.name == word:
+                return {'contents': _utils.format_docstring(d.docstring()) or ''}
+
         return {'contents': ''}
-
-    # raw docstring returns only doc, without signature
-    doc = _utils.format_docstring(definition.docstring(raw=True))
-
-    # Find first exact matching signature
-    signature = next((x.to_string() for x in definition.get_signatures() if x.name == word), '')
-
-    contents = []
-    if signature:
-        contents.append({
-            'language': 'python',
-            'value': signature,
-        })
-    if doc:
-        contents.append(doc)
-    if not contents:
-        return {'contents': ''}
-    return {'contents': contents}

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             'pycodestyle',
             'pydocstyle>=2.0.0',
             'pyflakes>=1.6.0',
-            'pylint>=2.4.0',
+            'pylint',
             'rope>=0.10.5',
             'yapf',
         ],

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             'pycodestyle',
             'pydocstyle>=2.0.0',
             'pyflakes>=1.6.0',
-            'pylint',
+            'pylint>=2.4.0',
             'rope>=0.10.5',
             'yapf',
         ],

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'configparser; python_version<"3.0"',
         'future>=0.14.0; python_version<"3"',
         'backports.functools_lru_cache; python_version<"3.2"',
-        'jedi>=0.15.0,<0.16',
+        'jedi>=0.14.1,<0.16',
         'python-jsonrpc-server>=0.1.0',
         'pluggy'
     ],

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -45,8 +45,6 @@ def test_rope_import_completion(config, workspace):
     assert items is None
 
 
-@pytest.mark.skipif(LooseVersion(jedi.__version__) < LooseVersion('0.14.0'),
-                    reason='This test fails with previous versions of Jedi')
 def test_jedi_completion(config):
     # Over 'i' in os.path.isabs(...)
     com_position = {'line': 1, 'character': 15}

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -1,8 +1,4 @@
 # Copyright 2017 Palantir Technologies, Inc.
-from distutils.version import LooseVersion
-import jedi
-import pytest
-
 from pyls import uris
 from pyls.plugins.definition import pyls_definitions
 from pyls.workspace import Document
@@ -38,8 +34,6 @@ def test_definitions(config):
     assert [{'uri': DOC_URI, 'range': def_range}] == pyls_definitions(config, doc, cursor_pos)
 
 
-@pytest.mark.skipif(LooseVersion(jedi.__version__) < LooseVersion('0.14.0'),
-                    reason='This test fails with previous versions of jedi')
 def test_builtin_definition(config):
     # Over 'i' in dict
     cursor_pos = {'line': 8, 'character': 24}

--- a/test/plugins/test_hover.py
+++ b/test/plugins/test_hover.py
@@ -1,5 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
-from pyls import uris
+from distutils.version import LooseVersion
+
+from pyls import uris, _utils
 from pyls.plugins.hover import pyls_hover
 from pyls.workspace import Document
 
@@ -20,8 +22,13 @@ def test_hover():
 
     doc = Document(DOC_URI, DOC)
 
+    if LooseVersion(_utils.JEDI_VERSION) >= LooseVersion('0.15.0'):
+        contents = [{'language': 'python', 'value': 'main()'}, 'hello world']
+    else:
+        contents = 'main()\n\nhello world'
+
     assert {
-        'contents': [{'language': 'python', 'value': 'main()'}, 'hello world']
+        'contents': contents
     } == pyls_hover(doc, hov_position)
 
     assert {'contents': ''} == pyls_hover(doc, no_hov_position)

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -1,8 +1,4 @@
 # Copyright 2017 Palantir Technologies, Inc.
-from distutils.version import LooseVersion
-import jedi
-import pytest
-
 from pyls import uris
 from pyls.plugins.symbols import pyls_document_symbols
 from pyls.lsp import SymbolKind
@@ -25,8 +21,6 @@ def main(x):
 """
 
 
-@pytest.mark.skipif(LooseVersion(jedi.__version__) < LooseVersion('0.14.0'),
-                    reason='This test fails with previous versions of jedi')
 def test_symbols(config):
     doc = Document(DOC_URI, DOC)
     config.update({'plugins': {'jedi_symbols': {'all_scopes': False}}})


### PR DESCRIPTION
This support was removed in PR #623, but it was discovered in PR #682 that Jedi 0.15 breaks completions for scientific libraries like Numpy and Pandas.