### PR TITLE
Don't go to definition of builtin modules

### DIFF
--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -21,5 +21,6 @@ def pyls_definitions(config, document, position):
             }
         }
         for d in definitions
-        if d.is_definition() and d.line is not None and d.column is not None and d.module_path is not None and not d.in_builtin_module()
+        if d.is_definition() and d.line is not None and d.column is not None and d.module_path is not None
+        and not d.in_builtin_module()
     ]

--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -21,5 +21,5 @@ def pyls_definitions(config, document, position):
             }
         }
         for d in definitions
-        if d.is_definition() and d.line is not None and d.column is not None and d.module_path is not None
+        if d.is_definition() and d.line is not None and d.column is not None and d.module_path is not None and not d.in_builtin_module()
     ]

--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -20,11 +20,11 @@ def pyls_definitions(config, document, position):
                 'end': {'line': d.line - 1, 'character': d.column + len(d.name)},
             }
         }
-        for d in definitions if d.is_definition() and not_internal_definition(d)
+        for d in definitions if d.is_definition() and _not_internal_definition(d)
     ]
 
 
-def not_internal_definition(definition):
+def _not_internal_definition(definition):
     return (
         definition.line is not None and
         definition.column is not None and

--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -21,6 +21,6 @@ def pyls_definitions(config, document, position):
             }
         }
         for d in definitions
-        if d.is_definition() and d.line is not None and d.column is not None and d.module_path is not None
-        and not d.in_builtin_module()
+        if d.is_definition() and d.line is not None and d.column is not None and
+        d.module_path is not None and not d.in_builtin_module()
     ]

--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -20,7 +20,14 @@ def pyls_definitions(config, document, position):
                 'end': {'line': d.line - 1, 'character': d.column + len(d.name)},
             }
         }
-        for d in definitions
-        if d.is_definition() and d.line is not None and d.column is not None and
-        d.module_path is not None and not d.in_builtin_module()
+        for d in definitions if d.is_definition() and not_internal_definition(d)
     ]
+
+
+def not_internal_definition(definition):
+    return (
+        definition.line is not None and
+        definition.column is not None and
+        definition.module_path is not None and
+        not definition.in_builtin_module()
+    )

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -40,7 +40,7 @@ def test_builtin_definition(config):
 
     # No go-to def for builtins
     doc = Document(DOC_URI, DOC)
-    assert len(pyls_definitions(config, doc, cursor_pos)) == 1
+    assert [] == pyls_definitions(config, doc, cursor_pos)
 
 
 def test_assignment(config):

--- a/test/plugins/test_definitions.py
+++ b/test/plugins/test_definitions.py
@@ -40,7 +40,7 @@ def test_builtin_definition(config):
 
     # No go-to def for builtins
     doc = Document(DOC_URI, DOC)
-    assert [] == pyls_definitions(config, doc, cursor_pos)
+    assert not pyls_definitions(config, doc, cursor_pos)
 
 
 def test_assignment(config):


### PR DESCRIPTION
If you do Go To Definition (F12 in vscode) on a string, it opens the builtins.pyi file for python 3, because the definition is not being filtered properly.

This PR corrects that behaviour so that neither python 2 nor 3 will go to the builtins file.

This doesn't affect the behaviour with imported builtins - they still respect the configuration.