### PR TITLE
Fix snippets behaviour in an import statement

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -54,8 +54,7 @@ def pyls_completions(config, document, position):
 
     if use_snippets(document, position):
         return [_format_completion(d, snippet_support and should_include_params) for d in definitions] or None
-    else:
-        return [_format_completion(d, False) for d in definitions] or None
+    return [_format_completion(d, False) for d in definitions] or None
 
 
 def use_snippets(document, position):

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -58,10 +58,10 @@ def pyls_completions(config, document, position):
 
 def use_snippets(document, position):
     """
-    Determine if returning snippets in code completions.
+    Determine if it's necessary to return snippets in code completions.
 
-    Returns False if the completion is running on an import statement
-    Returns True otherwise
+    This returns `False` if a completion is being requested on an import
+    statement, `True` otherwise.
     """
     lines = document.source.split('\n')
     act_line = lines[position['line']]

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -51,10 +51,9 @@ def pyls_completions(config, document, position):
 
     settings = config.plugin_settings('jedi_completion', document_path=document.path)
     should_include_params = settings.get('include_params')
-
-    if use_snippets(document, position):
-        return [_format_completion(d, snippet_support and should_include_params) for d in definitions] or None
-    return [_format_completion(d, False) for d in definitions] or None
+    include_params = (use_snippets(document, position) and
+                      snippet_support and should_include_params)
+    return [_format_completion(d, include_params) for d in definitions] or None
 
 
 def use_snippets(document, position):

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -150,3 +150,19 @@ def test_matplotlib_completions(config):
 
     assert items
     assert any(['plot' in i['label'] for i in items])
+
+
+def test_snippets_completion(config):
+    doc_snippets = 'from collections import defaultdict \na=defaultdict'
+    com_position = {'line': 0, 'character': 35}
+    doc = Document(DOC_URI, doc_snippets)
+    config.capabilities['textDocument'] = {
+        'completion': {'completionItem': {'snippetSupport': True}}}
+    config.update({'plugins': {'jedi_completion': {'include_params': True}}})
+    completions = pyls_jedi_completions(config, doc, com_position)
+    assert completions[0]['insertText'] == 'defaultdict'
+
+    com_position = {'line': 1, 'character': len(doc_snippets)}
+    completions = pyls_jedi_completions(config, doc, com_position)
+    out = 'defaultdict(${1:default_factory}, ${2:iterable}, ${3:kwargs})$0'
+    assert completions[0]['insertText'] == out


### PR DESCRIPTION
This change allows to determine if the user is writing an import statement and only return the completion without the snippets.

Fixes spyder-ide/spyder#10276.