### PR TITLE
Use ujson instead of regular json

### DIFF
--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -1,10 +1,13 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import argparse
-import json
 import logging
 import logging.config
 import sys
-from .python_ls import start_io_lang_server, start_tcp_lang_server, PythonLanguageServer
+
+import ujson as json
+
+from .python_ls import (PythonLanguageServer, start_io_lang_server,
+                        start_tcp_lang_server)
 
 LOG_FORMAT = "%(asctime)s UTC - %(levelname)s - %(name)s - %(message)s"
 

--- a/pyls/plugins/pylint_lint.py
+++ b/pyls/plugins/pylint_lint.py
@@ -1,13 +1,12 @@
 # Copyright 2018 Google LLC.
 """Linter plugin for pylint."""
 import collections
-import json
 import logging
 import sys
 
+import ujson as json
 from pylint.epylint import py_run
 from pyls import hookimpl, lsp
-
 
 log = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
         'backports.functools_lru_cache; python_version<"3.2"',
         'jedi>=0.14.1,<0.16',
         'python-jsonrpc-server>=0.1.0',
-        'pluggy'
+        'pluggy',
+        'ujson<=1.35'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
as it is faster

pylint checks use regular json. It is pretty slow and would be better if it used ujson instead
https://github.com/dignio/ultrajson
https://artem.krylysov.com/blog/2015/09/29/benchmark-python-json-libraries/

related to https://github.com/palantir/python-jsonrpc-server/pull/24