### PR TITLE
Increase minimal python-jsonrpc-server version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'future>=0.14.0; python_version<"3"',
         'backports.functools_lru_cache; python_version<"3.2"',
         'jedi>=0.14.1,<0.16',
-        'python-jsonrpc-server>=0.1.0',
+        'python-jsonrpc-server>=0.3.0',
         'pluggy',
         'ujson<=1.35'
     ],


### PR DESCRIPTION
This is to take advantage of the usage of `ujson` in that version to have a faster communications layer.