### PR TITLE
Disable Pylint plugin by default

### DIFF
--- a/pyls/plugins/pylint_lint.py
+++ b/pyls/plugins/pylint_lint.py
@@ -147,6 +147,13 @@ def _build_pylint_flags(settings):
 
 
 @hookimpl
+def pyls_settings():
+    # Default pylint to disabled because it requires a config
+    # file to be useful.
+    return {'plugins': {'pylint': {'enabled': False, 'args': []}}}
+
+
+@hookimpl
 def pyls_lint(config, document, is_saved):
     settings = config.plugin_settings('pylint')
     log.debug("Got pylint settings: %s", settings)

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -237,7 +237,7 @@
                 },
                 "pyls.plugins.pylint.enabled": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Enable or disable the plugin."
                 },
                 "pyls.plugins.pylint.args": {


### PR DESCRIPTION
- Pylint generates too much warnings without a configuration file. Users that rely on it probably know this, so it's better to let them enable the plugin in an opt-in manner.
- This follows the example set by the flake8 plugin too.