### PR TITLE
Show completions with and without params

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -43,11 +43,6 @@ _TYPE_MAP = {
 # Types of parso nodes for which snippet is not included in the completion
 _IMPORTS = ('import_name', 'import_from')
 
-# Provide completions with snippets
-_USE_PARAMS_OFF = 0
-_USE_PARAMS_ON = 1
-_USE_PARAMS_BOTH = 2
-
 
 @hookimpl
 def pyls_completions(config, document, position):
@@ -62,13 +57,6 @@ def pyls_completions(config, document, position):
     should_include_params = settings.get('include_params')
     include_params = (snippet_support and should_include_params and
                       use_snippets(document, position))
-    if include_params:
-        if settings.get('include_params_both'):
-            include_params = _USE_PARAMS_BOTH
-        else:
-            include_params = _USE_PARAMS_ON
-    else:
-        include_params = _USE_PARAMS_OFF
 
     return list(chain.from_iterable(_format_completions(d, include_params) for d in definitions))
 
@@ -96,12 +84,9 @@ def use_snippets(document, position):
 
 
 def _format_completions(d, include_params):
-    if include_params == _USE_PARAMS_BOTH:
-        yield _format_completion(d, False)
-        if hasattr(d, 'params'):
-            yield _format_completion(d, True)
-    else:
-        yield _format_completion(d, include_params == _USE_PARAMS_ON and hasattr(d, 'params'))
+    yield _format_completion(d, False)
+    if hasattr(d, 'params'):
+        yield _format_completion(d, True)
 
 
 def _format_completion(d, include_params):

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
-import parso
 from itertools import chain
+import parso
 from pyls import hookimpl, lsp, _utils
 
 log = logging.getLogger(__name__)

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -85,7 +85,7 @@ def use_snippets(document, position):
 
 def _format_completions(d, include_params):
     yield _format_completion(d, False)
-    if hasattr(d, 'params'):
+    if include_params and hasattr(d, 'params'):
         yield _format_completion(d, True)
 
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -170,24 +170,11 @@ def test_snippets_completion(config):
 
     com_position = {'line': 1, 'character': len(doc_snippets)}
     completions = pyls_jedi_completions(config, doc, com_position)
-    out = 'defaultdict(${1:default_factory}, ${2:iterable}, ${3:kwargs})$0'
-    assert completions[0]['insertText'] == out
-
-
-def test_snippets_both(config):
-    document = 'from datetime import date; a=date'
-    doc = Document(DOC_URI, document)
-    config.capabilities['textDocument'] = {
-        'completion': {'completionItem': {'snippetSupport': True}}}
-    config.update({'plugins': {'jedi_completion': {'include_params': True, 'include_params_both': True}}})
-
-    position = {'line': 0, 'character': len(document)}
-    completions = pyls_jedi_completions(config, doc, position)
     assert len(completions) == 2
-    assert completions[0]['insertText'] == 'date'
-    assert completions[0]['label'] == 'date'
-    assert completions[1]['insertText'] == 'date(${1:year}, ${2:month}, ${3:day})$0'
-    assert completions[1]['label'] == 'date(year, month, day)'
+    assert completions[0]['insertText'] == 'defaultdict'
+    assert completions[0]['label'] == 'defaultdict'
+    assert completions[1]['insertText'] == 'defaultdict(${1:default_factory}, ${2:iterable}, ${3:kwargs})$0'
+    assert completions[1]['label'] == 'defaultdict(default_factory, iterable, kwargs)'
 
 
 def test_multiline_snippets(config):
@@ -221,7 +208,7 @@ def test_multistatement_snippet(config):
     doc = Document(DOC_URI, document)
     position = {'line': 0, 'character': len(document)}
     completions = pyls_jedi_completions(config, doc, position)
-    assert completions[0]['insertText'] == 'date(${1:year}, ${2:month}, ${3:day})$0'
+    assert completions[1]['insertText'] == 'date(${1:year}, ${2:month}, ${3:day})$0'
 
 
 def test_jedi_completion_extra_paths(config, tmpdir):

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -58,7 +58,7 @@ def test_jedi_completion(config):
     items = pyls_jedi_completions(config, doc, com_position)
 
     assert items
-    assert items[0]['label'] == 'isabs(path)'
+    assert items[0]['label'] == 'isabs'
 
     # Test we don't throw with big character
     pyls_jedi_completions(config, doc, {'line': 1, 'character': 1000})
@@ -84,7 +84,7 @@ def test_jedi_completion_ordering(config):
     items = {c['label']: c['sortText'] for c in completions}
 
     # And that 'hidden' functions come after unhidden ones
-    assert items['hello()'] < items['_a_hello()']
+    assert items['hello'] < items['_a_hello']
 
 
 def test_jedi_property_completion(config):
@@ -108,7 +108,7 @@ def test_jedi_method_completion(config):
     config.update({'plugins': {'jedi_completion': {'include_params': True}}})
 
     completions = pyls_jedi_completions(config, doc, com_position)
-    everyone_method = [completion for completion in completions if completion['label'] == 'everyone(a, b, c, d)'][0]
+    everyone_method = [completion for completion in completions if completion['label'] == 'everyone(a, b)'][0]
 
     # Ensure we only generate snippets for positional args
     assert everyone_method['insertTextFormat'] == lsp.InsertTextFormat.Snippet
@@ -118,7 +118,7 @@ def test_jedi_method_completion(config):
     config.update({'plugins': {'jedi_completion': {'include_params': False}}})
 
     completions = pyls_jedi_completions(config, doc, com_position)
-    everyone_method = [completion for completion in completions if completion['label'] == 'everyone(a, b, c, d)'][0]
+    everyone_method = [completion for completion in completions if completion['label'] == 'everyone'][0]
 
     assert 'insertTextFormat' not in everyone_method
     assert everyone_method['insertText'] == 'everyone'
@@ -172,6 +172,22 @@ def test_snippets_completion(config):
     completions = pyls_jedi_completions(config, doc, com_position)
     out = 'defaultdict(${1:default_factory}, ${2:iterable}, ${3:kwargs})$0'
     assert completions[0]['insertText'] == out
+
+
+def test_snippets_both(config):
+    document = 'from datetime import date; a=date'
+    doc = Document(DOC_URI, document)
+    config.capabilities['textDocument'] = {
+        'completion': {'completionItem': {'snippetSupport': True}}}
+    config.update({'plugins': {'jedi_completion': {'include_params': True, 'include_params_both': True}}})
+
+    position = {'line': 0, 'character': len(document)}
+    completions = pyls_jedi_completions(config, doc, position)
+    assert len(completions) == 2
+    assert completions[0]['insertText'] == 'date'
+    assert completions[0]['label'] == 'date'
+    assert completions[1]['insertText'] == 'date(${1:year}, ${2:month}, ${3:day})$0'
+    assert completions[1]['label'] == 'date(year, month, day)'
 
 
 def test_multiline_snippets(config):
@@ -236,7 +252,7 @@ foo.s"""
     # After 'foo.s' with extra paths
     com_position = {'line': 1, 'character': 5}
     completions = pyls_jedi_completions(config, doc, com_position)
-    assert completions[0]['label'] == 'spam()'
+    assert completions[0]['label'] == 'spam'
 
 
 @pytest.mark.skipif(PY2 or not LINUX or not CI, reason="tested on linux and python 3 only")

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -186,7 +186,7 @@ def test_snippet_parsing(config):
     config.update({'plugins': {'jedi_completion': {'include_params': True}}})
     completions = pyls_jedi_completions(config, doc, completion_position)
     out = 'logical_and(${1:x1}, ${2:x2}, ${3:\\/}, ${4:*})$0'
-    assert completions[0]['insertText'] == out
+    assert completions[1]['insertText'] == out
 
 
 def test_multiline_snippets(config):


### PR DESCRIPTION
In some cases I don't want completion with snippets:

```python
class Foo(object):
    def __init__(self, a, b, c):
        pass

class Bar(Foo|
```

```python
from datetime import date, datetime

if foo:
    fn = date|
else:
    fn = datetime|
```

```python
def foo(a, b, c):
    pass

def bar(a, b, c):
    pass

z = foo(a, b, c)

# And now I need to replace `foo` with `bar`
z = bar|(a, b, c)
```

Assume cursor is at `|` and completions are invoked. Applying completion will insert snippet and I must delete it in order to have just class/function name.

IMO there are no way we can properly decide to include params or not.

My proposal is to include both candidates without and with params in completions list.

This PR add new option `include_params_both`. With `include_params` and `include_params_both` enabled completions list will include both variants.

There also side change: `label` is always equal to `insertText` in completion item. Is there any reason to completion label include all params?