### PR TITLE
PR: Fix snippet parsing when a slash character is present

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -103,7 +103,6 @@ def _format_completion(d, include_params=True):
             if i < len(positional_args) - 1:
                 snippet += ', '
         snippet += ')$0'
-        print(snippet)
         completion['insertText'] = snippet
 
     return completion

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -98,10 +98,12 @@ def _format_completion(d, include_params=True):
         completion['insertTextFormat'] = lsp.InsertTextFormat.Snippet
         snippet = d.name + '('
         for i, param in enumerate(positional_args):
-            snippet += '${%s:%s}' % (i + 1, param.name)
+            name = param.name if param.name != '/' else '\\/'
+            snippet += '${%s:%s}' % (i + 1, name)
             if i < len(positional_args) - 1:
                 snippet += ', '
         snippet += ')$0'
+        print(snippet)
         completion['insertText'] = snippet
 
     return completion

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -174,6 +174,18 @@ def test_snippets_completion(config):
     assert completions[0]['insertText'] == out
 
 
+def test_snippet_parsing(config):
+    doc = 'import numpy as np\nnp.logical_and'
+    completion_position = {'line': 1, 'character': 14}
+    doc = Document(DOC_URI, doc)
+    config.capabilities['textDocument'] = {
+        'completion': {'completionItem': {'snippetSupport': True}}}
+    config.update({'plugins': {'jedi_completion': {'include_params': True}}})
+    completions = pyls_jedi_completions(config, doc, completion_position)
+    out = 'logical_and(${1:x1}, ${2:x2}, ${3:\\/}, ${4:*})$0'
+    assert completions[0]['insertText'] == out
+
+
 def test_multiline_snippets(config):
     document = 'from datetime import\\\n date,\\\n datetime \na=date'
     doc = Document(DOC_URI, document)


### PR DESCRIPTION
Fixes the syntax of the snippet when a slash (`/`) character is present.

Fixes https://github.com/spyder-ide/spyder/issues/10761

![snippet](https://user-images.githubusercontent.com/20992645/69158308-381c6f00-0ab4-11ea-9341-af7417b100f8.gif)

