### PR TITLE
Don't include params notations in snippet

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -92,18 +92,23 @@ def _format_completion(d, include_params=True):
     }
 
     if include_params and hasattr(d, 'params') and d.params:
-        positional_args = [param for param in d.params if '=' not in param.description]
-
         # For completions with params, we can generate a snippet instead
-        completion['insertTextFormat'] = lsp.InsertTextFormat.Snippet
-        snippet = d.name + '('
-        for i, param in enumerate(positional_args):
-            name = param.name if param.name != '/' else '\\/'
-            snippet += '${%s:%s}' % (i + 1, name)
-            if i < len(positional_args) - 1:
-                snippet += ', '
-        snippet += ')$0'
-        completion['insertText'] = snippet
+
+        def positional_args():
+            # return params until / or kwarg
+            for param in d.params:
+                if param.name in {'/', '*'} or '=' in param.description:
+                    break
+                yield param
+
+        snippet_params = ', '.join(
+            '${{{}:{}}}'.format(i + 1, param.name) for i, param in enumerate(positional_args())
+        )
+
+        completion.update(
+            insertTextFormat=lsp.InsertTextFormat.Snippet,
+            insertText='{}({})$0'.format(d.name, snippet_params)
+        )
 
     return completion
 

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -92,18 +92,25 @@ def _format_completion(d, include_params=True):
     }
 
     if include_params and hasattr(d, 'params') and d.params:
-        positional_args = [param for param in d.params if '=' not in param.description]
-
         # For completions with params, we can generate a snippet instead
-        completion['insertTextFormat'] = lsp.InsertTextFormat.Snippet
-        snippet = d.name + '('
-        for i, param in enumerate(positional_args):
-            name = param.name if param.name != '/' else '\\/'
-            snippet += '${%s:%s}' % (i + 1, name)
-            if i < len(positional_args) - 1:
-                snippet += ', '
-        snippet += ')$0'
-        completion['insertText'] = snippet
+
+        def positional_args():
+            # return params until kwarg
+            for param in d.params:
+                if param.name == '/':
+                    continue
+                if param.name == '*' or '=' in param.description:
+                    break
+                yield param
+
+        snippet_params = ', '.join(
+            '${{{}:{}}}'.format(i + 1, param.name) for i, param in enumerate(positional_args())
+        )
+
+        completion.update(
+            insertTextFormat=lsp.InsertTextFormat.Snippet,
+            insertText='{}({})$0'.format(d.name, snippet_params)
+        )
 
     return completion
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -182,7 +182,7 @@ def test_snippet_parsing(config):
         'completion': {'completionItem': {'snippetSupport': True}}}
     config.update({'plugins': {'jedi_completion': {'include_params': True}}})
     completions = pyls_jedi_completions(config, doc, completion_position)
-    out = 'logical_and(${1:x1}, ${2:x2}, ${3:\\/}, ${4:*})$0'
+    out = 'logical_and(${1:x1}, ${2:x2})$0'
     assert completions[0]['insertText'] == out
 
 


### PR DESCRIPTION
Related PR: https://github.com/palantir/python-language-server/pull/701

`/` and `*` in parameters list are not parameters but notations. See [PEP570](https://www.python.org/dev/peps/pep-0570/#syntax-and-semantics).