### PR TITLE
Remove ujson dependency on Windows (requires MSVC compiler)

### DIFF
--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -6,7 +6,7 @@ import sys
 
 try:
     import ujson as json
-except Exception:
+except ImportError:
     import json
 
 from .python_ls import (PythonLanguageServer, start_io_lang_server,

--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -6,7 +6,7 @@ import sys
 
 try:
     import ujson as json
-except ImportError:
+except Exception:  # pylint: disable=broad-except
     import json
 
 from .python_ls import (PythonLanguageServer, start_io_lang_server,

--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -4,7 +4,10 @@ import logging
 import logging.config
 import sys
 
-import ujson as json
+try:
+    import ujson as json
+except Exception:
+    import json
 
 from .python_ls import (PythonLanguageServer, start_io_lang_server,
                         start_tcp_lang_server)

--- a/pyls/plugins/pylint_lint.py
+++ b/pyls/plugins/pylint_lint.py
@@ -4,9 +4,13 @@ import collections
 import logging
 import sys
 
-import ujson as json
 from pylint.epylint import py_run
 from pyls import hookimpl, lsp
+
+try:
+    import ujson as json
+except Exception:
+    import json
 
 log = logging.getLogger(__name__)
 

--- a/pyls/plugins/pylint_lint.py
+++ b/pyls/plugins/pylint_lint.py
@@ -9,7 +9,7 @@ from pyls import hookimpl, lsp
 
 try:
     import ujson as json
-except Exception:
+except ImportError:
     import json
 
 log = logging.getLogger(__name__)

--- a/pyls/plugins/pylint_lint.py
+++ b/pyls/plugins/pylint_lint.py
@@ -9,7 +9,7 @@ from pyls import hookimpl, lsp
 
 try:
     import ujson as json
-except ImportError:
+except Exception:  # pylint: disable=broad-except
     import json
 
 log = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ setup(
         'future>=0.14.0; python_version<"3"',
         'backports.functools_lru_cache; python_version<"3.2"',
         'jedi>=0.14.1,<0.16',
-        'python-jsonrpc-server>=0.3.0',
+        'python-jsonrpc-server>=0.3.1',
         'pluggy',
-        'ujson<=1.35; platform_system=="Linux"'
+        'ujson<=1.35; platform_system!="Windows"'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'jedi>=0.14.1,<0.16',
         'python-jsonrpc-server>=0.3.0',
         'pluggy',
-        'ujson<=1.35'
+        'ujson<=1.35; platform_system=="Linux"'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'future>=0.14.0; python_version<"3"',
         'backports.functools_lru_cache; python_version<"3.2"',
         'jedi>=0.14.1,<0.16',
-        'python-jsonrpc-server>=0.3.1',
+        'python-jsonrpc-server>=0.3.2',
         'pluggy',
         'ujson<=1.35; platform_system!="Windows"'
     ],


### PR DESCRIPTION
As discussed with @ccordoba12
Fixes spyder-ide/spyder#10763

Depends on  palantir/python-jsonrpc-server#26 and a new release of `python-jsonrpc-server`

### TODO:
 - [x] Bump up min version required for `python-jsonrpc-server`
 - [x] Fix tests