### PR TITLE
Fix TCPServer being bound before allow_reuse_address is set

### DIFF
--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -68,10 +68,12 @@ def start_tcp_lang_server(bind_addr, port, check_parent_process, handler_class):
          'SHUTDOWN_CALL': shutdown_server}
     )
 
-    server = socketserver.TCPServer((bind_addr, port), wrapper_class)
+    server = socketserver.TCPServer((bind_addr, port), wrapper_class, bind_and_activate=False)
     server.allow_reuse_address = True
 
     try:
+        server.server_bind()
+        server.server_activate()
         log.info('Serving %s on (%s, %s)', handler_class.__name__, bind_addr, port)
         server.serve_forever()
     finally:


### PR DESCRIPTION
Currently, `server_bind` is [being called](https://github.com/python/cpython/blob/3.8/Lib/socketserver.py#L452) before `allow_reuse_address` is set on the `TCPServer` instance. This leads to the flag having no effect.

This patch adjusts the code to call `server_bind` only after setting the flag.

See the bottom of [this stackoverflow answer](https://stackoverflow.com/a/42147927) for more context.