### PR TITLE
Fix: Run pytest in parallel using xdist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,5 +14,6 @@ exclude = test/plugins/.ropeproject,test/.ropeproject
 [tool:pytest]
 testpaths = test
 addopts =
+    -n 4
     --cov-report html --cov-report term --junitxml=pytest.xml
     --cov pyls --cov test

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'pylint': ['pylint'],
         'rope': ['rope>0.10.5'],
         'yapf': ['yapf'],
-        'test': ['versioneer', 'pylint', 'pytest', 'mock', 'pytest-cov',
+        'test': ['versioneer', 'pylint', 'pytest-xdist', 'mock', 'pytest-cov',
                  'coverage', 'numpy', 'pandas', 'matplotlib',
                  'pyqt5;python_version>="3"'],
     },


### PR DESCRIPTION
This runs pytest in parallel by using xdist instead. Pytest takes around ~64.88s  in my machine, it now takes around ~41.23s, which is a plus when running tests within CircleCI