### PR TITLE
Only add snippet completions when positional args are available

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -84,6 +84,7 @@ def is_exception_class(name):
         # class definition in Python 2
         return False
 
+
 def use_snippets(document, position):
     """
     Determine if it's necessary to return snippets in code completions.
@@ -115,8 +116,8 @@ def use_snippets(document, position):
     code = '\n'.join(act_lines).split(';')[-1].strip() + last_character
     tokens = parso.parse(code)
     expr_type = tokens.children[0].type
-    return  (expr_type not in _IMPORTS and
-             not (expr_type in _ERRORS and 'import' in code))
+    return (expr_type not in _IMPORTS and
+            not (expr_type in _ERRORS and 'import' in code))
 
 
 def _format_completion(d, include_params=True):

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -90,7 +90,7 @@ def use_snippets(document, position):
             if act_line.rstrip().endswith('('):
                 # Needs to be added to the end of the code before parsing
                 # to make it valid, otherwise the node type could end
-                # being an 'error_node'
+                # being an 'error_node' for multi-line imports that use '('
                 last_character = ')'
         else:
             break

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -103,16 +103,17 @@ def _format_completion(d, include_params=True):
     if include_params and hasattr(d, 'params') and d.params:
         positional_args = [param for param in d.params if '=' not in param.description]
 
-        # For completions with params, we can generate a snippet instead
-        completion['insertTextFormat'] = lsp.InsertTextFormat.Snippet
-        snippet = d.name + '('
-        for i, param in enumerate(positional_args):
-            name = param.name if param.name != '/' else '\\/'
-            snippet += '${%s:%s}' % (i + 1, name)
-            if i < len(positional_args) - 1:
-                snippet += ', '
-        snippet += ')$0'
-        completion['insertText'] = snippet
+        if len(positional_args) > 1:
+            # For completions with params, we can generate a snippet instead
+            completion['insertTextFormat'] = lsp.InsertTextFormat.Snippet
+            snippet = d.name + '('
+            for i, param in enumerate(positional_args):
+                name = param.name if param.name != '/' else '\\/'
+                snippet += '${%s:%s}' % (i + 1, name)
+                if i < len(positional_args) - 1:
+                    snippet += ', '
+            snippet += ')$0'
+            completion['insertText'] = snippet
 
     return completion
 

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -82,9 +82,9 @@ def use_snippets(document, position):
     last_character = ''
     while line > -1:
         act_line = lines[line]
-        if (act_line.rstrip().endswith('\\')
-                or act_line.rstrip().endswith('(')
-                or act_line.rstrip().endswith(',')):
+        if (act_line.rstrip().endswith('\\') or
+                act_line.rstrip().endswith('(') or
+                act_line.rstrip().endswith(',')):
             act_lines.insert(0, act_line)
             line -= 1
             if act_line.rstrip().endswith('('):

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -79,14 +79,23 @@ def use_snippets(document, position):
     lines = document.source.split('\n', line)
     act_lines = [lines[line][:position['character']]]
     line -= 1
+    last_character = ''
     while line > -1:
         act_line = lines[line]
-        if act_line.rstrip().endswith('\\'):
+        if (act_line.rstrip().endswith('\\')
+                or act_line.rstrip().endswith('(')
+                or act_line.rstrip().endswith(',')):
             act_lines.insert(0, act_line)
             line -= 1
+            if act_line.rstrip().endswith('('):
+                # Needs to be added to the end of the code before parsing
+                # to make it valid, otherwise the node type could end
+                # being an 'error_node'
+                last_character = ')'
         else:
             break
-    tokens = parso.parse('\n'.join(act_lines).split(';')[-1].strip())
+    tokens = parso.parse(
+        '\n'.join(act_lines).split(';')[-1].strip() + last_character)
     return tokens.children[0].type not in _IMPORTS
 
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -189,7 +189,7 @@ def test_snippets_completion(config):
 
     com_position = {'line': 1, 'character': len(doc_snippets)}
     completions = pyls_jedi_completions(config, doc, com_position)
-    out = 'defaultdict(${1:kwargs})$0'
+    out = 'defaultdict'
     assert completions[0]['insertText'] == out
 
 
@@ -203,6 +203,22 @@ def test_snippet_parsing(config):
     completions = pyls_jedi_completions(config, doc, completion_position)
     out = 'logical_and(${1:x1}, ${2:x2}, ${3:\\/}, ${4:*})$0'
     assert completions[0]['insertText'] == out
+
+
+def test_multiline_import_snippets(config):
+    document = 'from datetime import(\n date,\n datetime)\na=date'
+    doc = Document(DOC_URI, document)
+    config.capabilities['textDocument'] = {
+        'completion': {'completionItem': {'snippetSupport': True}}}
+    config.update({'plugins': {'jedi_completion': {'include_params': True}}})
+
+    position = {'line': 1, 'character': 5}
+    completions = pyls_jedi_completions(config, doc, position)
+    assert completions[0]['insertText'] == 'date'
+
+    position = {'line': 2, 'character': 9}
+    completions = pyls_jedi_completions(config, doc, position)
+    assert completions[0]['insertText'] == 'datetime'
 
 
 def test_multiline_snippets(config):

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -189,8 +189,7 @@ def test_snippets_completion(config):
 
     com_position = {'line': 1, 'character': len(doc_snippets)}
     completions = pyls_jedi_completions(config, doc, com_position)
-    out = 'defaultdict'
-    assert completions[0]['insertText'] == out
+    assert completions[0]['insertText'] == 'defaultdict($0)'
 
 
 def test_snippet_parsing(config):


### PR DESCRIPTION
* Prevents the creation of snippets completions with none or single arguments like `..()$0` or `..(${1:args})$0`.

* Prevents the creation of snippets completions for multi-line imports statements like:
```python
from collections import (
    defaultdict)
```

Fixes spyder-ide/spyder#11356