### PR TITLE
Fix m_workspace__did_change_workspace_folders to follow the spec

### DIFF
--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -361,7 +361,12 @@ class PythonLanguageServer(MethodDispatcher):
             for doc_uri in workspace.documents:
                 self.lint(doc_uri, is_saved=False)
 
-    def m_workspace__did_change_workspace_folders(self, added=None, removed=None, **_kwargs):
+    def m_workspace__did_change_workspace_folders(self, event=None, **_kwargs):
+        if event is None:
+            return
+        added = event.get('added', [])
+        removed = event.get('removed', [])
+
         for removed_info in removed:
             removed_uri = removed_info['uri']
             self.workspaces.pop(removed_uri)

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -96,7 +96,7 @@ def test_multiple_workspaces(tmpdir, pyls):
 
     added_workspaces = [{'uri': path_as_uri(str(x))}
                         for x in (workspace1_dir, workspace2_dir)]
-    event = { 'added': added_workspaces, 'removed': []}
+    event = {'added': added_workspaces, 'removed': []}
     pyls.m_workspace__did_change_workspace_folders(event)
 
     for workspace in added_workspaces:
@@ -116,6 +116,6 @@ def test_multiple_workspaces(tmpdir, pyls):
     workspace2_uri = added_workspaces[1]['uri']
     assert msg['uri'] in pyls.workspaces[workspace2_uri]._docs
 
-    event = { 'added': [], 'removed': [added_workspaces[0]]}
+    event = {'added': [], 'removed': [added_workspaces[0]]}
     pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace1_uri not in pyls.workspaces

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -96,8 +96,8 @@ def test_multiple_workspaces(tmpdir, pyls):
 
     added_workspaces = [{'uri': path_as_uri(str(x))}
                         for x in (workspace1_dir, workspace2_dir)]
-    pyls.m_workspace__did_change_workspace_folders(
-        added=added_workspaces, removed=[])
+    event = { 'added': added_workspaces, 'removed': []}
+    pyls.m_workspace__did_change_workspace_folders(event)
 
     for workspace in added_workspaces:
         assert workspace['uri'] in pyls.workspaces
@@ -116,6 +116,6 @@ def test_multiple_workspaces(tmpdir, pyls):
     workspace2_uri = added_workspaces[1]['uri']
     assert msg['uri'] in pyls.workspaces[workspace2_uri]._docs
 
-    pyls.m_workspace__did_change_workspace_folders(
-        added=[], removed=[added_workspaces[0]])
+    event = { 'added': [], 'removed': [added_workspaces[0]]}
+    pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace1_uri not in pyls.workspaces


### PR DESCRIPTION
Changed signature for `m_workspace__did_change_workspace_folders` according to microsofts language-server-protocol [`DidChangeWorkspaceFolders`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_didChangeWorkspaceFolders).

see #720