### PR TITLE
Fixed keyError if a workspace uri is wrong for a removed workspace

### DIFF
--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -361,7 +361,12 @@ class PythonLanguageServer(MethodDispatcher):
             for doc_uri in workspace.documents:
                 self.lint(doc_uri, is_saved=False)
 
-    def m_workspace__did_change_workspace_folders(self, added=None, removed=None, **_kwargs):
+    def m_workspace__did_change_workspace_folders(self, event=None, **_kwargs):
+        if event is None:
+            return
+        added = event.get('added', [])
+        removed = event.get('removed', [])
+
         for removed_info in removed:
             removed_uri = removed_info['uri']
             self.workspaces.pop(removed_uri)

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -369,7 +369,7 @@ class PythonLanguageServer(MethodDispatcher):
 
         for removed_info in removed:
             removed_uri = removed_info['uri']
-            self.workspaces.pop(removed_uri)
+            self.workspaces.pop(removed_uri, None)
 
         for added_info in added:
             added_uri = added_info['uri']

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -96,7 +96,7 @@ def test_multiple_workspaces(tmpdir, pyls):
 
     added_workspaces = [{'uri': path_as_uri(str(x))}
                         for x in (workspace1_dir, workspace2_dir)]
-    event = { 'added': added_workspaces, 'removed': []}
+    event = {'added': added_workspaces, 'removed': []}
     pyls.m_workspace__did_change_workspace_folders(event)
 
     for workspace in added_workspaces:
@@ -116,6 +116,6 @@ def test_multiple_workspaces(tmpdir, pyls):
     workspace2_uri = added_workspaces[1]['uri']
     assert msg['uri'] in pyls.workspaces[workspace2_uri]._docs
 
-    event = { 'added': [], 'removed': [added_workspaces[0]]}
+    event = {'added': [], 'removed': [added_workspaces[0]]}
     pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace1_uri not in pyls.workspaces

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -119,3 +119,9 @@ def test_multiple_workspaces(tmpdir, pyls):
     event = {'added': [], 'removed': [added_workspaces[0]]}
     pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace1_uri not in pyls.workspaces
+
+def test_multiple_workspaces_wrong_removed_uri(tmpdir, pyls):
+    workspace = {'uri': 'Test123'}
+    event = {'added': [], 'removed': [workspace]}
+    pyls.m_workspace__did_change_workspace_folders(event)
+    assert workspace['uri'] not in pyls.workspaces

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -120,9 +120,9 @@ def test_multiple_workspaces(tmpdir, pyls):
     pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace1_uri not in pyls.workspaces
 
+
 def test_multiple_workspaces_wrong_removed_uri(pyls):
     workspace = {'uri': 'Test123'}
     event = {'added': [], 'removed': [workspace]}
     pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace['uri'] not in pyls.workspaces
-

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -125,3 +125,4 @@ def test_multiple_workspaces_wrong_removed_uri(pyls):
     event = {'added': [], 'removed': [workspace]}
     pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace['uri'] not in pyls.workspaces
+

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -120,7 +120,7 @@ def test_multiple_workspaces(tmpdir, pyls):
     pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace1_uri not in pyls.workspaces
 
-def test_multiple_workspaces_wrong_removed_uri(tmpdir, pyls):
+def test_multiple_workspaces_wrong_removed_uri(pyls):
     workspace = {'uri': 'Test123'}
     event = {'added': [], 'removed': [workspace]}
     pyls.m_workspace__did_change_workspace_folders(event)

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -96,8 +96,8 @@ def test_multiple_workspaces(tmpdir, pyls):
 
     added_workspaces = [{'uri': path_as_uri(str(x))}
                         for x in (workspace1_dir, workspace2_dir)]
-    pyls.m_workspace__did_change_workspace_folders(
-        added=added_workspaces, removed=[])
+    event = { 'added': added_workspaces, 'removed': []}
+    pyls.m_workspace__did_change_workspace_folders(event)
 
     for workspace in added_workspaces:
         assert workspace['uri'] in pyls.workspaces
@@ -116,6 +116,6 @@ def test_multiple_workspaces(tmpdir, pyls):
     workspace2_uri = added_workspaces[1]['uri']
     assert msg['uri'] in pyls.workspaces[workspace2_uri]._docs
 
-    pyls.m_workspace__did_change_workspace_folders(
-        added=[], removed=[added_workspaces[0]])
+    event = { 'added': [], 'removed': [added_workspaces[0]]}
+    pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace1_uri not in pyls.workspaces


### PR DESCRIPTION
Fixed keyError if a workspace uri is wrong for a removed workspace in `m_workspace__did_change_workspace_folders` + added simple Test.

Discovered in #720 

Rebased on #749 / works only on top of #749 