### PR TITLE
Remove slash and star from positional snippets

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -141,8 +141,8 @@ def _format_completion(d, include_params=True):
     if (include_params and hasattr(d, 'params') and d.params and
             not is_exception_class(d.name)):
         positional_args = [param for param in d.params
-                           if '=' not in param.description or
-                           param.name in {'/', '*'}]
+                           if '=' not in param.description and
+                           param.name not in {'/', '*'}]
 
         if len(positional_args) > 1:
             # For completions with params, we can generate a snippet instead

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -140,15 +140,16 @@ def _format_completion(d, include_params=True):
 
     if (include_params and hasattr(d, 'params') and d.params and
             not is_exception_class(d.name)):
-        positional_args = [param for param in d.params if '=' not in param.description]
+        positional_args = [param for param in d.params
+                           if '=' not in param.description or
+                           param.name in {'/', '*'}]
 
         if len(positional_args) > 1:
             # For completions with params, we can generate a snippet instead
             completion['insertTextFormat'] = lsp.InsertTextFormat.Snippet
             snippet = d.name + '('
             for i, param in enumerate(positional_args):
-                name = param.name if param.name != '/' else '\\/'
-                snippet += '${%s:%s}' % (i + 1, name)
+                snippet += '${%s:%s}' % (i + 1, param.name)
                 if i < len(positional_args) - 1:
                     snippet += ', '
             snippet += ')$0'

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -200,7 +200,7 @@ def test_snippet_parsing(config):
         'completion': {'completionItem': {'snippetSupport': True}}}
     config.update({'plugins': {'jedi_completion': {'include_params': True}}})
     completions = pyls_jedi_completions(config, doc, completion_position)
-    out = 'logical_and(${1:x1}, ${2:x2}, ${3:\\/}, ${4:*})$0'
+    out = 'logical_and(${1:x1}, ${2:x2})$0'
     assert completions[0]['insertText'] == out
 
 


### PR DESCRIPTION
This PR removes ``*`` and ``/`` from function arguments when generating snippets.