### PR TITLE
Fix hover request for numpy alias (np) and ufuncs

### DIFF
--- a/pyls/plugins/hover.py
+++ b/pyls/plugins/hover.py
@@ -16,6 +16,12 @@ def pyls_hover(document, position):
         # Find first exact matching definition
         definition = next((x for x in definitions if x.name == word), None)
 
+        # Ensure a definition is used if only one is available
+        # even if the word doesn't match. An example of this case is 'np'
+        # where 'numpy' doesn't match with 'np'. Same for NumPy ufuncs
+        if len(definitions) == 1:
+            definition = definitions[0]
+
         if not definition:
             return {'contents': ''}
 

--- a/test/plugins/test_hover.py
+++ b/test/plugins/test_hover.py
@@ -20,6 +20,7 @@ np.sin
 
 """
 
+
 def test_numpy_hover():
     # Over the blank line
     no_hov_position = {'line': 1, 'character': 0}
@@ -35,28 +36,21 @@ def test_numpy_hover():
     doc = Document(DOC_URI, NUMPY_DOC)
 
     if LooseVersion(_utils.JEDI_VERSION) >= LooseVersion('0.15.0'):
-        contents = [
-            {'language': 'python', 'value': 'numpy'},
-            'NumPy\n=====\n\nProvides\n\xa0\xa01. '
-            'An array object of arbitrary homogeneous items\n\xa0\xa02.']
-        assert contents in pyls_hover(doc, numpy_hov_position_1)['contents']
+        contents = ''
+        assert contents in pyls_hover(doc, no_hov_position)['contents']
 
-        contents = [
-            {'language': 'python', 'value': 'numpy'},
-            'NumPy\n=====\n\nProvides\n\xa0\xa01. '
-            'An array object of arbitrary homogeneous items\n\xa0\xa02.']
-        assert contents in pyls_hover(doc, numpy_hov_position_2)['contents']
+        contents = 'NumPy\n=====\n\nProvides\n'
+        assert contents in pyls_hover(doc, numpy_hov_position_1)['contents'][0]
 
-        contents = [
-            {'language': 'python', 'value': 'numpy'},
-            'NumPy\n=====\n\nProvides\n\xa0\xa01. '
-            'An array object of arbitrary homogeneous items\n\xa0\xa02.']
-        assert contents in pyls_hover(doc, numpy_hov_position_3)['contents']
+        contents = 'NumPy\n=====\n\nProvides\n'
+        assert contents in pyls_hover(doc, numpy_hov_position_2)['contents'][0]
 
-        contents = [
-            {'language': 'python', 'value': 'numpy'},
-            'Trigonometric sine, element-wise.\n\n']
-        assert contents in pyls_hover(doc, numpy_sin_hov_position)['contents']
+        contents = 'NumPy\n=====\n\nProvides\n'
+        assert contents in pyls_hover(doc, numpy_hov_position_3)['contents'][0]
+
+        contents = 'Trigonometric sine, element-wise.\n\n'
+        assert contents in pyls_hover(
+            doc, numpy_sin_hov_position)['contents'][0]
 
 
 def test_hover():

--- a/test/plugins/test_hover.py
+++ b/test/plugins/test_hover.py
@@ -13,6 +13,51 @@ def main():
     pass
 """
 
+NUMPY_DOC = """
+
+import numpy as np
+np.sin
+
+"""
+
+def test_numpy_hover():
+    # Over the blank line
+    no_hov_position = {'line': 1, 'character': 0}
+    # Over 'numpy' in import numpy as np
+    numpy_hov_position_1 = {'line': 2, 'character': 8}
+    # Over 'np' in import numpy as np
+    numpy_hov_position_2 = {'line': 2, 'character': 17}
+    # Over 'np' in np.sin
+    numpy_hov_position_3 = {'line': 3, 'character': 1}
+    # Over 'sin' in np.sin
+    numpy_sin_hov_position = {'line': 3, 'character': 4}
+
+    doc = Document(DOC_URI, NUMPY_DOC)
+
+    if LooseVersion(_utils.JEDI_VERSION) >= LooseVersion('0.15.0'):
+        contents = [
+            {'language': 'python', 'value': 'numpy'},
+            'NumPy\n=====\n\nProvides\n\xa0\xa01. '
+            'An array object of arbitrary homogeneous items\n\xa0\xa02.']
+        assert contents in pyls_hover(doc, numpy_hov_position_1)['contents']
+
+        contents = [
+            {'language': 'python', 'value': 'numpy'},
+            'NumPy\n=====\n\nProvides\n\xa0\xa01. '
+            'An array object of arbitrary homogeneous items\n\xa0\xa02.']
+        assert contents in pyls_hover(doc, numpy_hov_position_2)['contents']
+
+        contents = [
+            {'language': 'python', 'value': 'numpy'},
+            'NumPy\n=====\n\nProvides\n\xa0\xa01. '
+            'An array object of arbitrary homogeneous items\n\xa0\xa02.']
+        assert contents in pyls_hover(doc, numpy_hov_position_3)['contents']
+
+        contents = [
+            {'language': 'python', 'value': 'numpy'},
+            'Trigonometric sine, element-wise.\n\n']
+        assert contents in pyls_hover(doc, numpy_sin_hov_position)['contents']
+
 
 def test_hover():
     # Over 'main' in def main():


### PR DESCRIPTION
With @ccordoba12 we noticed that hover requests were not working for `np` or NumPy ufuncs like `np.sin` since the validation of definitions with `x.name == word` fails. For example:

* `name -> numpy` vs `word -> np`
* `name -> ufunc` vs `word -> sin`)

This PR proposes to not do the validation mentioned in case only one definition is returned by Jedi, and take that unique definition to respond the hover request.
