### PR TITLE
Add support for autopep8 aggressive option from config file

### DIFF
--- a/pyls/config/pycodestyle_conf.py
+++ b/pyls/config/pycodestyle_conf.py
@@ -15,6 +15,7 @@ OPTIONS = [
     ('ignore', 'plugins.pycodestyle.ignore', list),
     ('max-line-length', 'plugins.pycodestyle.maxLineLength', int),
     ('select', 'plugins.pycodestyle.select', list),
+    ('aggressive', 'plugins.pycodestyle.aggressive', int),
 ]
 
 

--- a/pyls/plugins/autopep8_format.py
+++ b/pyls/plugins/autopep8_format.py
@@ -57,6 +57,7 @@ def _autopep8_config(config):
         'ignore': settings.get('ignore'),
         'max_line_length': settings.get('maxLineLength'),
         'select': settings.get('select'),
+        'aggressive': settings.get('aggressive'),
     }
 
     # Filter out null options


### PR DESCRIPTION
This is so the user can specify aggressive option in pycodestyle config file.
e.g. in ~/.config/pycodestyle
```
[pycodestyle]
aggressive = 2
```
This seems to work. E.g.
No aggressive option leave this code as is:
```python
if x == None:
```
With above pycodestyle and pull request, it makes this change:
```python
if x is None:
```

Anyone who reads this: higher aggressive options than 0 should be used with care, as x is None does not always mean the same as x == None.