### PR TITLE
Fix an issue when re.match returns None

### DIFF
--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -118,10 +118,16 @@ def parse_stdout(document, stdout):
     diagnostics = []
     lines = stdout.splitlines()
     for raw_line in lines:
-        parsed_line = re.match(r'(.*):(\d*):(\d*): (\w*) (.*)', raw_line).groups()
-        if not parsed_line or len(parsed_line) != 5:
+        parsed_line = re.match(r'(.*):(\d*):(\d*): (\w*) (.*)', raw_line)
+        if not parsed_line:
             log.debug("Flake8 output parser can't parse line '%s'", raw_line)
             continue
+
+        parsed_line = parsed_line.groups()
+        if len(parsed_line) != 5:
+            log.debug("Flake8 output parser can't parse line '%s'", raw_line)
+            continue
+
         _, line, character, code, msg = parsed_line
         line = int(line) - 1
         character = int(character) - 1


### PR DESCRIPTION
`re.match` can return `None`, so we can't just simply call `.object` on the result.