### PR TITLE
Allow passing explicit environment variables to Jedi environment

### DIFF
--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -257,8 +257,7 @@ class Document(object):
 
         return jedi.Script(**kwargs)
 
-    def get_enviroment(self, environment_path=None, **kwargs):
-        # TODO: when safe to break API, use env_vars explicitly to pass to create_environment
+    def get_enviroment(self, environment_path=None, env_vars=None):
         # TODO(gatesn): #339 - make better use of jedi environments, they seem pretty powerful
         if environment_path is None:
             environment = jedi.api.environment.get_cached_default_environment()
@@ -267,15 +266,16 @@ class Document(object):
                 environment = self._workspace._environments[environment_path]
             else:
                 environment = jedi.api.environment.create_environment(path=environment_path,
-                                                                      safe=False, **kwargs)
+                                                                      safe=False,
+                                                                      env_vars=env_vars)
                 self._workspace._environments[environment_path] = environment
 
         return environment
 
-    def sys_path(self, environment_path=None, **kwargs):
+    def sys_path(self, environment_path=None, env_vars=None):
         # Copy our extra sys path
         # TODO: when safe to break API, use env_vars explicitly to pass to create_environment
         path = list(self._extra_sys_path)
-        environment = self.get_enviroment(environment_path=environment_path, **kwargs)
+        environment = self.get_enviroment(environment_path=environment_path, env_vars=env_vars)
         path.extend(environment.get_sys_path())
         return path

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -226,13 +226,13 @@ class Document(object):
     def jedi_script(self, position=None):
         extra_paths = []
         environment_path = None
-        env_vars = {}
+        env_vars = None
 
         if self._config:
             jedi_settings = self._config.plugin_settings('jedi', document_path=self.path)
             environment_path = jedi_settings.get('environment')
             extra_paths = jedi_settings.get('extra_paths') or []
-            env_vars = jedi_settings.get('env_vars') or {}
+            env_vars = jedi_settings.get('env_vars')
 
         environment = self.get_enviroment(environment_path, env_vars=env_vars) if environment_path else None
         sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -234,6 +234,12 @@ class Document(object):
             extra_paths = jedi_settings.get('extra_paths') or []
             env_vars = jedi_settings.get('env_vars')
 
+        # Drop PYTHONPATH from env_vars before creating the environment because that makes
+        # Jedi throw an error.
+        if env_vars is None:
+            env_vars = os.environ.copy()
+        env_vars.pop('PYTHONPATH', None)
+
         environment = self.get_enviroment(environment_path, env_vars=env_vars) if environment_path else None
         sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths
         project_path = self._workspace.root_path

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -226,14 +226,16 @@ class Document(object):
     def jedi_script(self, position=None):
         extra_paths = []
         environment_path = None
+        env_vars = {}
 
         if self._config:
             jedi_settings = self._config.plugin_settings('jedi', document_path=self.path)
             environment_path = jedi_settings.get('environment')
             extra_paths = jedi_settings.get('extra_paths') or []
+            env_vars = jedi_settings.get('env_vars') or {}
 
-        environment = self.get_enviroment(environment_path) if environment_path else None
-        sys_path = self.sys_path(environment_path) + extra_paths
+        environment = self.get_enviroment(environment_path, env_vars=env_vars) if environment_path else None
+        sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths
         project_path = self._workspace.root_path
 
         kwargs = {
@@ -249,7 +251,8 @@ class Document(object):
 
         return jedi.Script(**kwargs)
 
-    def get_enviroment(self, environment_path=None):
+    def get_enviroment(self, environment_path=None, **kwargs):
+        # TODO: when safe to break API, use env_vars explicitly to pass to create_environment
         # TODO(gatesn): #339 - make better use of jedi environments, they seem pretty powerful
         if environment_path is None:
             environment = jedi.api.environment.get_cached_default_environment()
@@ -257,14 +260,16 @@ class Document(object):
             if environment_path in self._workspace._environments:
                 environment = self._workspace._environments[environment_path]
             else:
-                environment = jedi.api.environment.create_environment(path=environment_path, safe=False)
+                environment = jedi.api.environment.create_environment(path=environment_path,
+                                                                      safe=False, **kwargs)
                 self._workspace._environments[environment_path] = environment
 
         return environment
 
-    def sys_path(self, environment_path=None):
+    def sys_path(self, environment_path=None, **kwargs):
         # Copy our extra sys path
+        # TODO: when safe to break API, use env_vars explicitly to pass to create_environment
         path = list(self._extra_sys_path)
-        environment = self.get_enviroment(environment_path=environment_path)
+        environment = self.get_enviroment(environment_path=environment_path, **kwargs)
         path.extend(environment.get_sys_path())
         return path

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
         'configparser; python_version<"3.0"',
         'future>=0.14.0; python_version<"3"',
         'backports.functools_lru_cache; python_version<"3.2"',
-        'jedi>=0.17.0,<0.18.0',
+        'jedi>=0.17.2,<0.18.0',
         'python-jsonrpc-server>=0.4.0',
         'pluggy',
         'ujson<=2.0.3 ; platform_system!="Windows" and python_version<"3.0"',

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -42,7 +42,7 @@
                 },
                 "pyls.plugins.jedi.env_vars": {
                     "type": "dictionary",
-                    "default": {},
+                    "default": null,
                     "description": "Define environment variables for jedi.Script and Jedi.names."
                 },
                 "pyls.plugins.jedi.environment": {

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -40,6 +40,11 @@
                     "default": [],
                     "description": "Define extra paths for jedi.Script."
                 },
+                "pyls.plugins.jedi.env_vars": {
+                    "type": "dictionary",
+                    "default": {},
+                    "description": "Define environment variables for jedi.Script and Jedi.names."
+                },
                 "pyls.plugins.jedi.environment": {
                     "type": "string",
                     "default": null,


### PR DESCRIPTION
This permits passing explicit environment variables to the jedi environment, which is just passed to `subprocess.Popen`'s `env` keyword argument. See davidhalter/jedi#1617 and davidhalter/jedi#1619.