### PR TITLE
Parse ignore arguments in flake8 to avoid issues with Atom

### DIFF
--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -7,8 +7,7 @@ from subprocess import Popen, PIPE
 from pyls import hookimpl, lsp
 
 log = logging.getLogger(__name__)
-# a quick temporary fix to deal with Atom
-_fix_ignores_re = re.compile(r'([^a-zA-Z0-9_,]*;.*(\W+||$))')
+FIX_IGNORES_RE = re.compile(r'([^a-zA-Z0-9_,]*;.*(\W+||$))')
 
 
 @hookimpl
@@ -50,7 +49,8 @@ def run_flake8(args):
     """Run flake8 with the provided arguments, logs errors
     from stderr if any.
     """
-    args = [(i if not i.startswith('--ignore=') else _fix_ignores_re.sub('', i))
+    # a quick temporary fix to deal with Atom
+    args = [(i if not i.startswith('--ignore=') else FIX_IGNORES_RE.sub('', i))
             for i in args if i is not None]
     log.debug("Calling flake8 with args: '%s'", args)
     try:

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -7,6 +7,8 @@ from subprocess import Popen, PIPE
 from pyls import hookimpl, lsp
 
 log = logging.getLogger(__name__)
+# a quick temporary fix to deal with Atom
+_fix_ignores_re = re.compile(r'([^a-zA-Z0-9_,]*;.*(\W+||$))')
 
 
 @hookimpl
@@ -48,6 +50,8 @@ def run_flake8(args):
     """Run flake8 with the provided arguments, logs errors
     from stderr if any.
     """
+    args = [(i if not i.startswith('--ignore=') else _fix_ignores_re.sub('', i))
+            for i in args if i is not None]
     log.debug("Calling flake8 with args: '%s'", args)
     try:
         cmd = ['flake8']


### PR DESCRIPTION
PR addresses #769 as a temporary solution. Basic diagnostic was done [here](https://github.com/palantir/python-language-server/issues/769#issuecomment-635922783) and a quickfix proposed [here](https://github.com/palantir/python-language-server/issues/769#issuecomment-635946863).

I did not have time to run the tests, hopefully CI will do it for us.
Also I don't know all the possible implications, maybe there are some more arguments need to be fixed.
I feel like these fixes need to be applied to Atom and its plugins. But, on the other hand having broken Atom used by millions of people is not good for PyLS too. Hope the Atom guys will manage to do their job solving the problem soon.

Fixes #769.