### PR TITLE
Profile completion

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -159,11 +159,12 @@ def use_snippets(document, position):
 def _format_completion(d, include_params=True, profile_ranges=None):
     t1 = datetime.now()
     completion = {
-        #'documentation': _utils.format_docstring(d.docstring()),
+        'documentation': _utils.format_docstring(d.docstring()),
     }
     t2 = datetime.now()
+    sig = d.get_signatures()
     completion.update({
-        'label': d.name,
+        'label': _label(d, sig),
         'kind': _TYPE_MAP.get(d.type),
         'sortText': _sort_text(d),
         'insertText': d.name,
@@ -177,10 +178,12 @@ def _format_completion(d, include_params=True, profile_ranges=None):
         path = path.replace('/', '\\/')
         completion['insertText'] = path
 
+    profile_ranges['documentation'] += (t2 - t1)
+    profile_ranges['update'] += (t3 - t2)
+    profile_ranges['total'] += (t3 - t1)
     if not include_params:
         return completion
 
-    sig = d.get_signatures()
     if sig and not is_exception_class(d.name):
         completion['label'] = _label(d, sig)
         positional_args = [param for param in sig[0].params
@@ -204,9 +207,6 @@ def _format_completion(d, include_params=True, profile_ranges=None):
             completion['insertText'] = d.name + '()'
     # t4 = datetime.now()
 
-    profile_ranges['documentation'] += (t2 - t1)
-    profile_ranges['update'] += (t3 - t2)
-    profile_ranges['total'] += (t3 - t1)
     # profile_ranges['path'] += (t3 - t2)
     # profile_ranges['forks'] += (t4 - t3)
 


### PR DESCRIPTION
Pull request for https://github.com/palantir/python-language-server/issues/823

I've done a little investigation so I can say that `Completion.get_signatures()` and `Completion.docstring()` slow down performance about 5 times. The results of the functions are not seen in completions for NeoVim/Vim at least so calling the functions is overhead for the case.

I dump time ranges in files /tmp/pyls_completions.prof for `pyls_completions` method and `/tmp/PythonLanguageServer.completions.prof` for `completions` method of `PythonLanguageServer` class.

Here are the results of the investigation:
```
==> pyls_completions.prof.fast <==
pyls_completions total 0:00:00.724521 format_profile_ranges defaultdict(<class 'datetime.timedelta'>, {'documentation': datetime.timedelta(microseconds=324), 'update': datetime.timedelta(microseconds=75766), 'total': datetime.timedelta(microseconds=76090)})
pyls_completions total 0:00:00.165487 format_profile_ranges defaultdict(<class 'datetime.timedelta'>, {'documentation': datetime.timedelta(microseconds=321), 'update': datetime.timedelta(microseconds=23167), 'total': datetime.timedelta(microseconds=23488)})
pyls_completions total 0:00:00.177044 format_profile_ranges defaultdict(<class 'datetime.timedelta'>, {'documentation': datetime.timedelta(microseconds=297), 'update': datetime.timedelta(microseconds=23520), 'total': datetime.timedelta(microseconds=23817)})

==> pyls_completions.prof.slow <==
pyls_completions total 0:00:01.708528 format_profile_ranges defaultdict(<class 'datetime.timedelta'>, {'documentation': datetime.timedelta(microseconds=626150), 'update': datetime.timedelta(microseconds=426714), 'total': datetime.timedelta(seconds=1, microseconds=52864)})
pyls_completions total 0:00:01.132067 format_profile_ranges defaultdict(<class 'datetime.timedelta'>, {'documentation': datetime.timedelta(microseconds=546148), 'update': datetime.timedelta(microseconds=432481), 'total': datetime.timedelta(microseconds=978629)})
pyls_completions total 0:00:01.099432 format_profile_ranges defaultdict(<class 'datetime.timedelta'>, {'documentation': datetime.timedelta(microseconds=535644), 'update': datetime.timedelta(microseconds=409444), 'total': datetime.timedelta(microseconds=945088)})
pyls_completions total 0:00:01.216887 format_profile_ranges defaultdict(<class 'datetime.timedelta'>, {'documentation': datetime.timedelta(microseconds=632716), 'update': datetime.timedelta(microseconds=429011), 'total': datetime.timedelta(seconds=1, microseconds=61727)})

==> PythonLanguageServer.completions.prof.fast <==
completions 0:00:00.725947
completions 0:00:00.166862
completions 0:00:00.178388

==> PythonLanguageServer.completions.prof.slow <==
completions 0:00:01.710710
completions 0:00:01.134438
completions 0:00:01.101723
completions 0:00:01.218994
```
The *.fast reports are done with commit a0d32bb; the *.slow reports are done with 21c484e.

The first one doesn't get signatures, documentation and labels for completions. Code in the latter commit differs from version from `develop` branch but does the same. As wrote the data is not required to get completions but it slows down performance 5 times after the first call. The first call is slower only 2 times because Jedi use sources instead of its internal cache. Tested script consists of `import os; os.`.

I don't have certain suggestions. The only idea I have is introducing new settings avoids getting documentation and pretty labels.