### PR TITLE
Read pycodestyle and flake8 configurations per workspace

### DIFF
--- a/pyls/config/config.py
+++ b/pyls/config/config.py
@@ -106,6 +106,13 @@ class Config(object):
         settings = {}
         sources = self._settings.get('configurationSources', DEFAULT_CONFIG_SOURCES)
 
+        # Plugin configuration
+        settings = _utils.merge_dicts(settings, self._plugin_settings)
+
+        # LSP configuration
+        settings = _utils.merge_dicts(settings, self._settings)
+
+        # User configuration
         for source_name in reversed(sources):
             source = self._config_sources.get(source_name)
             if not source:
@@ -113,14 +120,8 @@ class Config(object):
             source_conf = source.user_config()
             log.debug("Got user config from %s: %s", source.__class__.__name__, source_conf)
             settings = _utils.merge_dicts(settings, source_conf)
-        log.debug("With user configuration: %s", settings)
 
-        settings = _utils.merge_dicts(settings, self._plugin_settings)
-        log.debug("With plugin configuration: %s", settings)
-
-        settings = _utils.merge_dicts(settings, self._settings)
-        log.debug("With lsp configuration: %s", settings)
-
+        # Project configuration
         for source_name in reversed(sources):
             source = self._config_sources.get(source_name)
             if not source:
@@ -128,7 +129,8 @@ class Config(object):
             source_conf = source.project_config(document_path or self._root_path)
             log.debug("Got project config from %s: %s", source.__class__.__name__, source_conf)
             settings = _utils.merge_dicts(settings, source_conf)
-        log.debug("With project configuration: %s", settings)
+
+        log.debug("With configuration: %s", settings)
 
         return settings
 

--- a/pyls/config/source.py
+++ b/pyls/config/source.py
@@ -30,7 +30,6 @@ class ConfigSource(object):
         config = configparser.RawConfigParser()
         for filename in files:
             if os.path.exists(filename) and not os.path.isdir(filename):
-                log.debug("Reading config from %s", filename)
                 config.read(filename)
 
         return config

--- a/pyls/config/source.py
+++ b/pyls/config/source.py
@@ -30,6 +30,7 @@ class ConfigSource(object):
         config = configparser.RawConfigParser()
         for filename in files:
             if os.path.exists(filename) and not os.path.isdir(filename):
+                log.debug("Reading config from {}".format(filename))
                 config.read(filename)
 
         return config

--- a/pyls/config/source.py
+++ b/pyls/config/source.py
@@ -30,7 +30,7 @@ class ConfigSource(object):
         config = configparser.RawConfigParser()
         for filename in files:
             if os.path.exists(filename) and not os.path.isdir(filename):
-                log.debug("Reading config from {}".format(filename))
+                log.debug("Reading config from %s", filename)
                 config.read(filename)
 
         return config

--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -16,7 +16,8 @@ def pyls_settings():
 
 
 @hookimpl
-def pyls_lint(config, document):
+def pyls_lint(workspace, document):
+    config = workspace._config
     settings = config.plugin_settings('flake8')
     log.debug("Got flake8 settings: %s", settings)
 

--- a/pyls/plugins/pycodestyle_lint.py
+++ b/pyls/plugins/pycodestyle_lint.py
@@ -19,7 +19,8 @@ log = logging.getLogger(__name__)
 
 
 @hookimpl
-def pyls_lint(config, document):
+def pyls_lint(workspace, document):
+    config = workspace._config
     settings = config.plugin_settings('pycodestyle')
     log.debug("Got pycodestyle settings: %s", settings)
 

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -358,7 +358,7 @@ class PythonLanguageServer(MethodDispatcher):
         self.config.update((settings or {}).get('pyls', {}))
         for workspace_uri in self.workspaces:
             workspace = self.workspaces[workspace_uri]
-            workspace.update_config(self.config)
+            workspace.update_config(settings)
             for doc_uri in workspace.documents:
                 self.lint(doc_uri, is_saved=False)
 

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -376,7 +376,11 @@ class PythonLanguageServer(MethodDispatcher):
         for added_info in added:
             if 'uri' in added_info:
                 added_uri = added_info['uri']
-                self.workspaces[added_uri] = Workspace(added_uri, self._endpoint, self.config)
+                workspace_config = config.Config(
+                    added_uri, self.config._init_opts,
+                    self.config._process_id, self.config._capabilities)
+                self.workspaces[added_uri] = Workspace(
+                    added_uri, self._endpoint, workspace_config)
 
         root_workspace_removed = any(removed_info['uri'] == self.root_uri for removed_info in removed)
         workspace_added = len(added) > 0 and 'uri' in added[0]

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -397,9 +397,10 @@ class PythonLanguageServer(MethodDispatcher):
                 log.debug('Root workspace deleted!')
                 available_workspaces = sorted(self.workspaces)
                 first_workspace = available_workspaces[0]
-                self.config = first_workspace._config
+                new_root_workspace = self.workspaces[first_workspace]
                 self.root_uri = first_workspace
-                self.workspace = self.workspaces[first_workspace]
+                self.config = new_root_workspace._config
+                self.workspace = new_root_workspace
 
         # Migrate documents that are on the root workspace and have a better
         # match now

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -387,7 +387,9 @@ class PythonLanguageServer(MethodDispatcher):
         if root_workspace_removed and workspace_added:
             added_uri = added[0]['uri']
             self.root_uri = added_uri
-            self.workspace = self.workspaces[added_uri]
+            new_root_workspace = self.workspaces[added_uri]
+            self.config = new_root_workspace._config
+            self.workspace = new_root_workspace
         elif root_workspace_removed:
             # NOTE: Removing the root workspace can only happen when the server
             # is closed, thus the else condition of this if can never happen.
@@ -395,6 +397,7 @@ class PythonLanguageServer(MethodDispatcher):
                 log.debug('Root workspace deleted!')
                 available_workspaces = sorted(self.workspaces)
                 first_workspace = available_workspaces[0]
+                self.config = first_workspace._config
                 self.root_uri = first_workspace
                 self.workspace = self.workspaces[first_workspace]
 

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -106,23 +106,25 @@ class Workspace(object):
     def _create_document(self, doc_uri, source=None, version=None):
         path = uris.to_fs_path(doc_uri)
         return Document(
-            doc_uri, self, source=source, version=version,
+            doc_uri,
+            self,
+            source=source,
+            version=version,
             extra_sys_path=self.source_roots(path),
             rope_project_builder=self._rope_project_builder,
-            config=self._config,
         )
 
 
 class Document(object):
 
     def __init__(self, uri, workspace, source=None, version=None, local=True, extra_sys_path=None,
-                 rope_project_builder=None, config=None):
+                 rope_project_builder=None):
         self.uri = uri
         self.version = version
         self.path = uris.to_fs_path(uri)
         self.filename = os.path.basename(self.path)
 
-        self._config = config
+        self._config = workspace._config
         self._workspace = workspace
         self._local = local
         self._source = source

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -84,10 +84,10 @@ class Workspace(object):
         self._docs[doc_uri].apply_change(change)
         self._docs[doc_uri].version = version
 
-    def update_config(self, config):
-        self._config = config
+    def update_config(self, settings):
+        self._config.update((settings or {}).get('pyls', {}))
         for doc_uri in self.documents:
-            self.get_document(doc_uri).update_config(config)
+            self.get_document(doc_uri).update_config(settings)
 
     def apply_edit(self, edit):
         return self._endpoint.request(self.M_APPLY_EDIT, {'edit': edit})
@@ -147,8 +147,8 @@ class Document(object):
                 return f.read()
         return self._source
 
-    def update_config(self, config):
-        self._config = config
+    def update_config(self, settings):
+        self._config.update((settings or {}).get('pyls', {}))
 
     def apply_change(self, change):
         """Apply a change to the document."""

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -39,7 +39,9 @@ def pyls(tmpdir):
 @pytest.fixture
 def workspace(tmpdir):
     """Return a workspace."""
-    return Workspace(uris.from_fs_path(str(tmpdir)), Mock())
+    ws = Workspace(uris.from_fs_path(str(tmpdir)), Mock())
+    ws._config = Config(ws.root_uri, {}, 0, {})
+    return ws
 
 
 @pytest.fixture

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -2,7 +2,6 @@
 import os
 import sys
 
-from test.test_utils import MockWorkspace
 import pytest
 
 from pyls import uris, lsp
@@ -278,7 +277,7 @@ def test_multistatement_snippet(config, workspace):
     assert completions[0]['insertText'] == 'date(${1:year}, ${2:month}, ${3:day})$0'
 
 
-def test_jedi_completion_extra_paths(config, tmpdir, workspace):
+def test_jedi_completion_extra_paths(tmpdir, workspace):
     # Create a tempfile with some content and pass to extra_paths
     temp_doc_content = '''
 def spam():
@@ -296,7 +295,7 @@ foo.s"""
 
     # After 'foo.s' without extra paths
     com_position = {'line': 1, 'character': 5}
-    completions = pyls_jedi_completions(config, doc, com_position)
+    completions = pyls_jedi_completions(doc._config, doc, com_position)
     assert completions is None
 
     # Update config extra paths
@@ -305,33 +304,33 @@ foo.s"""
 
     # After 'foo.s' with extra paths
     com_position = {'line': 1, 'character': 5}
-    completions = pyls_jedi_completions(config, doc, com_position)
+    completions = pyls_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'spam()'
 
 
 @pytest.mark.skipif(PY2 or not LINUX or not CI, reason="tested on linux and python 3 only")
-def test_jedi_completion_environment(config):
+def test_jedi_completion_environment(workspace):
     # Content of doc to test completion
     doc_content = '''import logh
 '''
-    doc = Document(DOC_URI, MockWorkspace(), doc_content)
+    doc = Document(DOC_URI, workspace, doc_content)
 
     # After 'import logh' with default environment
     com_position = {'line': 0, 'character': 11}
 
     assert os.path.isdir('/tmp/pyenv/')
 
-    config.update({'plugins': {'jedi': {'environment': None}}})
-    doc.update_config(config)
-    completions = pyls_jedi_completions(config, doc, com_position)
+    settings = {'pyls': {'plugins': {'jedi': {'environment': None}}}}
+    doc.update_config(settings)
+    completions = pyls_jedi_completions(doc._config, doc, com_position)
     assert completions is None
 
     # Update config extra environment
     env_path = '/tmp/pyenv/bin/python'
-    config.update({'plugins': {'jedi': {'environment': env_path}}})
-    doc.update_config(config)
+    settings = {'pyls': {'plugins': {'jedi': {'environment': env_path}}}}
+    doc.update_config(settings)
 
     # After 'import logh' with new environment
-    completions = pyls_jedi_completions(config, doc, com_position)
+    completions = pyls_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'loghub'
     assert 'changelog generator' in completions[0]['documentation'].lower()

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -300,8 +300,8 @@ foo.s"""
     assert completions is None
 
     # Update config extra paths
-    config.update({'plugins': {'jedi': {'extra_paths': extra_paths}}})
-    doc.update_config(config)
+    settings = {'pyls': {'plugins': {'jedi': {'extra_paths': extra_paths}}}}
+    doc.update_config(settings)
 
     # After 'foo.s' with extra paths
     com_position = {'line': 1, 'character': 5}

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -29,19 +29,19 @@ def temp_document(doc_text):
     return name, doc
 
 
-def test_flake8_no_checked_file(config, workspace):
+def test_flake8_no_checked_file(workspace):
     # A bad uri or a non-saved file may cause the flake8 linter to do nothing.
     # In this situtation, the linter will return an empty list.
 
     doc = Document('', workspace, DOC)
-    diags = flake8_lint.pyls_lint(config, doc)
+    diags = flake8_lint.pyls_lint(workspace, doc)
     assert 'Error' in diags[0]['message']
 
 
-def test_flake8_lint(config):
+def test_flake8_lint(workspace):
     try:
         name, doc = temp_document(DOC)
-        diags = flake8_lint.pyls_lint(config, doc)
+        diags = flake8_lint.pyls_lint(workspace, doc)
         msg = 'local variable \'a\' is assigned to but never used'
         unused_var = [d for d in diags if d['message'] == msg][0]
 
@@ -55,14 +55,14 @@ def test_flake8_lint(config):
         os.remove(name)
 
 
-def test_flake8_config_param(config):
+def test_flake8_config_param(workspace):
     with patch('pyls.plugins.flake8_lint.Popen') as popen_mock:
         mock_instance = popen_mock.return_value
         mock_instance.communicate.return_value = [bytes(), bytes()]
         flake8_conf = '/tmp/some.cfg'
-        config.update({'plugins': {'flake8': {'config': flake8_conf}}})
+        workspace._config.update({'plugins': {'flake8': {'config': flake8_conf}}})
         _name, doc = temp_document(DOC)
-        flake8_lint.pyls_lint(config, doc)
+        flake8_lint.pyls_lint(workspace, doc)
         call_args = popen_mock.call_args.args[0]
         assert 'flake8' in call_args
         assert '--config={}'.format(flake8_conf) in call_args

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Palantir Technologies, Inc.
 import tempfile
 import os
-from test.test_utils import MockWorkspace
 from mock import patch
 from pyls import lsp, uris
 from pyls.plugins import flake8_lint
@@ -19,12 +18,12 @@ def using_const():
 """
 
 
-def temp_document(doc_text):
+def temp_document(doc_text, workspace):
     temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
     name = temp_file.name
     temp_file.write(doc_text)
     temp_file.close()
-    doc = Document(uris.from_fs_path(name), MockWorkspace())
+    doc = Document(uris.from_fs_path(name), workspace)
 
     return name, doc
 
@@ -40,7 +39,7 @@ def test_flake8_no_checked_file(workspace):
 
 def test_flake8_lint(workspace):
     try:
-        name, doc = temp_document(DOC)
+        name, doc = temp_document(DOC, workspace)
         diags = flake8_lint.pyls_lint(workspace, doc)
         msg = 'local variable \'a\' is assigned to but never used'
         unused_var = [d for d in diags if d['message'] == msg][0]
@@ -61,7 +60,7 @@ def test_flake8_config_param(workspace):
         mock_instance.communicate.return_value = [bytes(), bytes()]
         flake8_conf = '/tmp/some.cfg'
         workspace._config.update({'plugins': {'flake8': {'config': flake8_conf}}})
-        _name, doc = temp_document(DOC)
+        _name, doc = temp_document(DOC, workspace)
         flake8_lint.pyls_lint(workspace, doc)
         call_args = popen_mock.call_args.args[0]
         assert 'flake8' in call_args

--- a/test/plugins/test_pycodestyle_lint.py
+++ b/test/plugins/test_pycodestyle_lint.py
@@ -20,9 +20,9 @@ import json
 """
 
 
-def test_pycodestyle(config, workspace):
+def test_pycodestyle(workspace):
     doc = Document(DOC_URI, workspace, DOC)
-    diags = pycodestyle_lint.pyls_lint(config, doc)
+    diags = pycodestyle_lint.pyls_lint(workspace, doc)
 
     assert all([d['source'] == 'pycodestyle' for d in diags])
 
@@ -78,10 +78,9 @@ def test_pycodestyle_config(workspace):
     doc_uri = uris.from_fs_path(os.path.join(workspace.root_path, 'test.py'))
     workspace.put_document(doc_uri, DOC)
     doc = workspace.get_document(doc_uri)
-    config = Config(workspace.root_uri, {}, 1234, {})
 
     # Make sure we get a warning for 'indentation contains tabs'
-    diags = pycodestyle_lint.pyls_lint(config, doc)
+    diags = pycodestyle_lint.pyls_lint(workspace, doc)
     assert [d for d in diags if d['code'] == 'W191']
 
     content = {
@@ -93,10 +92,10 @@ def test_pycodestyle_config(workspace):
         # Now we'll add config file to ignore it
         with open(os.path.join(workspace.root_path, conf_file), 'w+') as f:
             f.write(content)
-        config.settings.cache_clear()
+        workspace._config.settings.cache_clear()
 
         # And make sure we don't get any warnings
-        diags = pycodestyle_lint.pyls_lint(config, doc)
+        diags = pycodestyle_lint.pyls_lint(workspace, doc)
         assert len([d for d in diags if d['code'] == 'W191']) == (0 if working else 1)
         assert len([d for d in diags if d['code'] == 'E201']) == (0 if working else 1)
         assert [d for d in diags if d['code'] == 'W391']
@@ -104,9 +103,9 @@ def test_pycodestyle_config(workspace):
         os.unlink(os.path.join(workspace.root_path, conf_file))
 
     # Make sure we can ignore via the PYLS config as well
-    config.update({'plugins': {'pycodestyle': {'ignore': ['W191', 'E201']}}})
+    workspace._config.update({'plugins': {'pycodestyle': {'ignore': ['W191', 'E201']}}})
     # And make sure we only get one warning
-    diags = pycodestyle_lint.pyls_lint(config, doc)
+    diags = pycodestyle_lint.pyls_lint(workspace, doc)
     assert not [d for d in diags if d['code'] == 'W191']
     assert not [d for d in diags if d['code'] == 'E201']
     assert [d for d in diags if d['code'] == 'W391']

--- a/test/plugins/test_pycodestyle_lint.py
+++ b/test/plugins/test_pycodestyle_lint.py
@@ -1,7 +1,6 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import os
 from pyls import lsp, uris
-from pyls.config.config import Config
 from pyls.workspace import Document
 from pyls.plugins import pycodestyle_lint
 

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -2,7 +2,6 @@
 import os
 import sys
 
-from test.test_utils import MockWorkspace
 import pytest
 
 from pyls import uris
@@ -80,12 +79,12 @@ def test_symbols_all_scopes(config, workspace):
 
 
 @pytest.mark.skipif(PY2 or not LINUX or not CI, reason="tested on linux and python 3 only")
-def test_symbols_all_scopes_with_jedi_environment(config):
-    doc = Document(DOC_URI, MockWorkspace(), DOC)
+def test_symbols_all_scopes_with_jedi_environment(config, workspace):
+    doc = Document(DOC_URI, workspace, DOC)
 
     # Update config extra environment
     env_path = '/tmp/pyenv/bin/python'
-    config.update({'plugins': {'jedi': {'environment': env_path}}})
-    doc.update_config(config)
-    symbols = pyls_document_symbols(config, doc)
+    settings = {'pyls': {'plugins': {'jedi': {'environment': env_path}}}}
+    doc.update_config(settings)
+    symbols = pyls_document_symbols(doc._config, doc)
     helper_check_symbols_all_scope(symbols)

--- a/test/plugins/test_symbols.py
+++ b/test/plugins/test_symbols.py
@@ -79,7 +79,7 @@ def test_symbols_all_scopes(config, workspace):
 
 
 @pytest.mark.skipif(PY2 or not LINUX or not CI, reason="tested on linux and python 3 only")
-def test_symbols_all_scopes_with_jedi_environment(config, workspace):
+def test_symbols_all_scopes_with_jedi_environment(workspace):
     doc = Document(DOC_URI, workspace, DOC)
 
     # Update config extra environment

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,6 +13,7 @@ class MockWorkspace(object):
     def __init__(self):
         """Mock workspace used by tests that use jedi environment."""
         self._environments = {}
+        self._config = None
 
         # This is to avoid pyling tests of the variable not being used
         sys.stdout.write(str(self._environments))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,5 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import time
-import sys
 
 import mock
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,21 +7,6 @@ import mock
 from pyls import _utils
 
 
-class MockWorkspace(object):
-    """Mock workspace used by tests that use jedi environment."""
-
-    def __init__(self):
-        """Mock workspace used by tests that use jedi environment."""
-        self._environments = {}
-        self._config = None
-
-        # This is to avoid pyling tests of the variable not being used
-        sys.stdout.write(str(self._environments))
-
-        # This necessary for the new Jedi 0.17+ API.
-        self.root_path = ''
-
-
 def test_debounce():
     interval = 0.1
     obj = mock.Mock()

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -121,20 +121,20 @@ def test_multiple_workspaces(tmpdir, pyls):
     assert workspace1_uri not in pyls.workspaces
 
 
-def test_multiple_workspaces_wrong_removed_uri(pyls):
-    workspace = {'uri': 'Test123'}
+def test_multiple_workspaces_wrong_removed_uri(pyls, tmpdir):
+    workspace = {'uri': str(tmpdir.mkdir('Test123'))}
     event = {'added': [], 'removed': [workspace]}
     pyls.m_workspace__did_change_workspace_folders(event)
     assert workspace['uri'] not in pyls.workspaces
 
 
-def test_root_workspace_changed(pyls):
-    test_uri = 'Test123'
+def test_root_workspace_changed(pyls, tmpdir):
+    test_uri = str(tmpdir.mkdir('Test123'))
     pyls.root_uri = test_uri
     pyls.workspace._root_uri = test_uri
 
     workspace1 = {'uri': test_uri}
-    workspace2 = {'uri': 'NewTest456'}
+    workspace2 = {'uri': str(tmpdir.mkdir('NewTest456'))}
 
     event = {'added': [workspace2], 'removed': [workspace1]}
     pyls.m_workspace__did_change_workspace_folders(event)
@@ -143,19 +143,19 @@ def test_root_workspace_changed(pyls):
     assert workspace2['uri'] == pyls.root_uri
 
 
-def test_root_workspace_not_changed(pyls):
+def test_root_workspace_not_changed(pyls, tmpdir):
     # removed uri != root_uri
-    test_uri_1 = 'Test12'
+    test_uri_1 = str(tmpdir.mkdir('Test12'))
     pyls.root_uri = test_uri_1
     pyls.workspace._root_uri = test_uri_1
-    workspace1 = {'uri': 'Test1234'}
-    workspace2 = {'uri': 'NewTest456'}
+    workspace1 = {'uri': str(tmpdir.mkdir('Test1234'))}
+    workspace2 = {'uri': str(tmpdir.mkdir('NewTest456'))}
     event = {'added': [workspace2], 'removed': [workspace1]}
     pyls.m_workspace__did_change_workspace_folders(event)
     assert test_uri_1 == pyls.workspace._root_uri
     assert test_uri_1 == pyls.root_uri
     # empty 'added' list
-    test_uri_2 = 'Test123'
+    test_uri_2 = str(tmpdir.mkdir('Test123'))
     new_root_uri = workspace2['uri']
     pyls.root_uri = test_uri_2
     pyls.workspace._root_uri = test_uri_2

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -197,3 +197,26 @@ def test_root_workspace_removed(tmpdir, pyls):
     # the root workspace
     assert pyls.root_uri == path_as_uri(str(workspace1_dir))
     assert pyls.workspace._root_uri == path_as_uri(str(workspace1_dir))
+
+
+def test_workspace_loads_pycodestyle_config(pyls, tmpdir):
+    test_uri = str(tmpdir.mkdir('Test123'))
+    pyls.root_uri = test_uri
+    pyls.workspace._root_uri = test_uri
+
+    new_path = tmpdir.mkdir('NewTest456')
+    cfg = new_path.join("pycodestyle.cfg")
+    cfg.write(
+        "[pycodestyle]\n"
+        "max-line-length = 1000"
+    )
+
+    workspace1 = {'uri': test_uri}
+    workspace2 = {'uri': str(new_path)}
+
+    event = {'added': [workspace2], 'removed': [workspace1]}
+    pyls.m_workspace__did_change_workspace_folders(event)
+
+    seetings = pyls.workspaces[str(new_path)]._config.settings()
+
+    assert seetings['plugins']['pycodestyle']['maxLineLength'] == 1000


### PR DESCRIPTION
This also gives more priority to the user config over the client one, so the last doesn't overshadow the first.

Fixes https://github.com/palantir/python-language-server/issues/819