### PR TITLE
Fix ValueError when formatting if continuation lines are incorrectly indented when using autopep8

### DIFF
--- a/test/plugins/test_autopep8_format.py
+++ b/test/plugins/test_autopep8_format.py
@@ -15,6 +15,25 @@ def func():
 
 GOOD_DOC = """A = ['hello', 'world']\n"""
 
+INDENTED_DOC = """def foo():
+    print('asdf',
+    file=None
+    )
+
+bar = { 'foo': foo
+}
+"""
+
+CORRECT_INDENTED_DOC = """def foo():
+    print('asdf',
+          file=None
+          )
+
+
+bar = {'foo': foo
+       }
+"""
+
 
 def test_format(config, workspace):
     doc = Document(DOC_URI, workspace, DOC)
@@ -42,3 +61,11 @@ def test_range_format(config, workspace):
 def test_no_change(config, workspace):
     doc = Document(DOC_URI, workspace, GOOD_DOC)
     assert not pyls_format_document(config, doc)
+
+
+def test_hanging_indentation(config, workspace):
+    doc = Document(DOC_URI, workspace, INDENTED_DOC)
+    res = pyls_format_document(config, doc)
+
+    assert len(res) == 1
+    assert res[0]['newText'] == CORRECT_INDENTED_DOC


### PR DESCRIPTION
This patch temporarily re-monkey-patches the _checks in pycodestyle to use autopep8's checker, and then patches things back when done. This should fix #771 

NB: the patching shouldn't need to be conditional (unlike in pycodestyle_lint.py) since autopep8 always requires pycodestyle to work.