### PR TITLE
PR: Fix compatibility with Jedi master

### DIFF
--- a/pyls/plugins/definition.py
+++ b/pyls/plugins/definition.py
@@ -16,7 +16,7 @@ def pyls_definitions(config, document, position):
 
     return [
         {
-            'uri': uris.uri_with(document.uri, path=d.module_path),
+            'uri': uris.uri_with(document.uri, path=str(d.module_path)),
             'range': {
                 'start': {'line': d.line - 1, 'character': d.column},
                 'end': {'line': d.line - 1, 'character': d.column + len(d.name)},

--- a/pyls/plugins/highlight.py
+++ b/pyls/plugins/highlight.py
@@ -14,7 +14,7 @@ def pyls_document_highlight(document, position):
         return definition.line is not None and definition.column is not None
 
     def local_to_document(definition):
-        return not definition.module_path or definition.module_path == document.path
+        return not definition.module_path or str(definition.module_path) == document.path
 
     return [{
         'range': {

--- a/pyls/plugins/jedi_rename.py
+++ b/pyls/plugins/jedi_rename.py
@@ -19,7 +19,7 @@ def pyls_rename(config, workspace, document, position, new_name):  # pylint: dis
     log.debug('Finished rename: %s', refactoring.get_diff())
     changes = []
     for file_path, changed_file in refactoring.get_changed_files().items():
-        uri = uris.from_fs_path(file_path)
+        uri = uris.from_fs_path(str(file_path))
         doc = workspace.get_maybe_document(uri)
         changes.append({
             'textDocument': {

--- a/pyls/plugins/references.py
+++ b/pyls/plugins/references.py
@@ -16,7 +16,7 @@ def pyls_references(document, position, exclude_declaration=False):
 
     # Filter out builtin modules
     return [{
-        'uri': uris.uri_with(document.uri, path=d.module_path) if d.module_path else document.uri,
+        'uri': uris.uri_with(document.uri, path=str(d.module_path)) if d.module_path else document.uri,
         'range': {
             'start': {'line': d.line - 1, 'character': d.column},
             'end': {'line': d.line - 1, 'character': d.column + len(d.name)}

--- a/test/plugins/test_references.py
+++ b/test/plugins/test_references.py
@@ -68,7 +68,7 @@ def test_references(tmp_workspace):  # pylint: disable=redefined-outer-name
 def test_references_builtin(tmp_workspace):  # pylint: disable=redefined-outer-name
     # Over 'UnicodeError':
     position = {'line': 4, 'character': 7}
-    doc2_uri = uris.from_fs_path(os.path.join(tmp_workspace.root_path, DOC2_NAME))
+    doc2_uri = uris.from_fs_path(os.path.join(str(tmp_workspace.root_path), DOC2_NAME))
     doc2 = Document(doc2_uri, tmp_workspace)
 
     refs = pyls_references(doc2, position)


### PR DESCRIPTION
- Newer versions of parso/jedi uses Path instead of str
- by converting to str pyls is compatibility with both old and new versions