### PR TITLE
Pinned `python-jsonrpc-server` to < 0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'future>=0.14.0; python_version<"3"',
         'backports.functools_lru_cache; python_version<"3.2"',
         'jedi>=0.17.0,<0.18.0',
-        'python-jsonrpc-server>=0.3.2',
+        'python-jsonrpc-server>=0.3.2,<0.4',
         'pluggy',
         'ujson<=1.35; platform_system!="Windows"'
     ],


### PR DESCRIPTION
Pinned `python-jsonrpc-server` to < 0.4 to avoid ujson error