### PR TITLE
Fix ujson dep for Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,9 @@ install_requires = [
         'backports.functools_lru_cache; python_version<"3.2"',
         'jedi>=0.17.0,<0.18.0',
         'python-jsonrpc-server>=0.4.0',
-        'pluggy']
-
-if sys.version_info[0] == 2:
-    install_requires.append('ujson<=2.0.3; platform_system!="Windows"')
-else:
-    install_requires.append('ujson>=3.0.0')
-
+        'pluggy',
+        'ujson<=2.0.3 ; platform_system!="Windows" and python_version<"3.0"',
+        'ujson>=3.0.0 ; python_version>"3"']
 
 setup(
     name='python-language-server',


### PR DESCRIPTION
The current logic doesn't seem to work, `pip install python-language-server` from a python2 environment yields

```
ERROR: Could not find a version that satisfies the requirement ujson>=3.0.0 (from python-language-server) (from versions: 1.4, 1.6, 1.8, 1.9, 1.15, 1.18, 1.19, 1.21, 1.22, 1.23, 1.30, 1.33, 1.34, 1.35, 2.0.0, 2.0.1, 2.0.2, 2.0.3)
ERROR: No matching distribution found for ujson>=3.0.0 (from python-language-server)
```

Fixes #863.