### PR TITLE
Pass server settings to new workspaces

### DIFF
--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -379,6 +379,7 @@ class PythonLanguageServer(MethodDispatcher):
                 workspace_config = config.Config(
                     added_uri, self.config._init_opts,
                     self.config._process_id, self.config._capabilities)
+                workspace_config.update(self.config._settings)
                 self.workspaces[added_uri] = Workspace(
                     added_uri, self._endpoint, workspace_config)
 

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -242,3 +242,23 @@ def test_workspace_loads_pycodestyle_config(pyls, tmpdir):
 
     seetings = pyls.workspaces[str(workspace3_dir)]._config.settings()
     assert seetings['plugins']['pycodestyle']['maxLineLength'] == 20
+
+
+def test_settings_of_added_workspace(pyls, tmpdir):
+    test_uri = str(tmpdir.mkdir('Test123'))
+    pyls.root_uri = test_uri
+    pyls.workspace._root_uri = test_uri
+
+    # Set some settings for the server.
+    server_settings = {'pyls': {'plugins': {'jedi': {'environment': '/usr/bin/python3'}}}}
+    pyls.m_workspace__did_change_configuration(server_settings)
+
+    # Create a new workspace.
+    workspace1 = {'uri': str(tmpdir.mkdir('NewTest456'))}
+    event = {'added': [workspace1]}
+    pyls.m_workspace__did_change_workspace_folders(event)
+
+    # Assert settings are inherited from the server config.
+    workspace1_object = pyls.workspaces[workspace1['uri']]
+    workspace1_jedi_settings = workspace1_object._config.plugin_settings('jedi')
+    assert workspace1_jedi_settings == server_settings['pyls']['plugins']['jedi']


### PR DESCRIPTION
This prevents workspaces created after the initial `didChangeConfiguration` request and before any other requests of that kind to have empty settings.