### PR TITLE
PR: Catch errors when trying to preload modules

### DIFF
--- a/pyls/plugins/preload_imports.py
+++ b/pyls/plugins/preload_imports.py
@@ -30,7 +30,8 @@ def pyls_initialize(config):
         try:
             __import__(mod_name)
             log.debug("Preloaded module %s", mod_name)
-        except (ImportError, ValueError):
-            # Catch ValueError since old versions of Numpy can cause it
+        except Exception:
+            # Catch any exception since not only ImportError can be raised here
+            # For example, old versions of NumPy can cause a ValueError.
             # See spyder-ide/spyder#13985
             pass

--- a/pyls/plugins/preload_imports.py
+++ b/pyls/plugins/preload_imports.py
@@ -30,5 +30,7 @@ def pyls_initialize(config):
         try:
             __import__(mod_name)
             log.debug("Preloaded module %s", mod_name)
-        except ImportError:
+        except (ImportError, ValueError):
+            # Catch ValueError since old versions of Numpy can cause it
+            # See spyder-ide/spyder#13985
             pass

--- a/pyls/plugins/preload_imports.py
+++ b/pyls/plugins/preload_imports.py
@@ -30,7 +30,7 @@ def pyls_initialize(config):
         try:
             __import__(mod_name)
             log.debug("Preloaded module %s", mod_name)
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             # Catch any exception since not only ImportError can be raised here
             # For example, old versions of NumPy can cause a ValueError.
             # See spyder-ide/spyder#13985


### PR DESCRIPTION
Old versions of NumPy can raise a `ValueError` that stop the proper initialization of the PyLS

Fixes spyder-ide/spyder#13985