### PR TITLE
Add plugin for syntax error detection with Jedi

### DIFF
--- a/pyls/plugins/jedi_lint.py
+++ b/pyls/plugins/jedi_lint.py
@@ -1,0 +1,28 @@
+from pyls import hookimpl, lsp
+
+@hookimpl
+def pyls_lint(config, document):
+    errors = document.jedi_script().get_syntax_errors()
+    diagnostics = []
+
+    for error in errors:
+        err_range = {
+            'start': {
+              'line': error.line - 1,
+               # Index columns start from 0
+               'character': error.column,
+            },
+            'end': {
+                'line': error.until_line - 1,
+                # It's possible that we're linting an empty file. Even an empty
+                # file might fail linting if it isn't named properly.
+                'character': error.until_column,
+                },
+            }
+        diagnostics.append({
+                'source': 'jedi',
+                'range': err_range,
+                'message': error.get_message(),
+                'severity': lsp.DiagnosticSeverity.Error,
+            })
+    return diagnostics

--- a/pyls/plugins/jedi_lint.py
+++ b/pyls/plugins/jedi_lint.py
@@ -1,17 +1,17 @@
 from pyls import hookimpl, lsp
 
+
 @hookimpl
-def pyls_lint(config, document):
+def pyls_lint(document):
     errors = document.jedi_script().get_syntax_errors()
     diagnostics = []
 
     for error in errors:
         err_range = {
             'start': {
-              'line': error.line - 1,
-               # Index columns start from 0
-               'character': error.column,
-            },
+                'line': error.line - 1,
+                'character': error.column,
+                },
             'end': {
                 'line': error.until_line - 1,
                 # It's possible that we're linting an empty file. Even an empty

--- a/pyls/plugins/jedi_lint.py
+++ b/pyls/plugins/jedi_lint.py
@@ -14,8 +14,6 @@ def pyls_lint(document):
             },
             'end': {
                 'line': error.until_line - 1,
-                # It's possible that we're linting an empty file. Even an empty
-                # file might fail linting if it isn't named properly.
                 'character': error.until_column,
             },
         }

--- a/pyls/plugins/jedi_lint.py
+++ b/pyls/plugins/jedi_lint.py
@@ -20,9 +20,9 @@ def pyls_lint(document):
                 },
             }
         diagnostics.append({
-                'source': 'jedi',
-                'range': err_range,
-                'message': error.get_message(),
-                'severity': lsp.DiagnosticSeverity.Error,
-            })
+            'source': 'jedi',
+            'range': err_range,
+            'message': error.get_message(),
+            'severity': lsp.DiagnosticSeverity.Error,
+        })
     return diagnostics

--- a/pyls/plugins/jedi_lint.py
+++ b/pyls/plugins/jedi_lint.py
@@ -11,14 +11,14 @@ def pyls_lint(document):
             'start': {
                 'line': error.line - 1,
                 'character': error.column,
-                },
+            },
             'end': {
                 'line': error.until_line - 1,
                 # It's possible that we're linting an empty file. Even an empty
                 # file might fail linting if it isn't named properly.
                 'character': error.until_column,
-                },
-            }
+            },
+        }
         diagnostics.append({
             'source': 'jedi',
             'range': err_range,

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
             'jedi_rename = pyls.plugins.jedi_rename',
             'jedi_signature_help = pyls.plugins.signature',
             'jedi_symbols = pyls.plugins.symbols',
+            'jedi_lint = pyls.plugins.jedi_lint',
             'mccabe = pyls.plugins.mccabe_lint',
             'preload = pyls.plugins.preload_imports',
             'pycodestyle = pyls.plugins.pycodestyle_lint',

--- a/test/plugins/test_jedi_lint.py
+++ b/test/plugins/test_jedi_lint.py
@@ -1,0 +1,60 @@
+from pyls import lsp, uris
+from pyls.workspace import Document
+from pyls.plugins import jedi_lint
+
+DOC_URI = uris.from_fs_path(__file__)
+DOC = """import sys
+
+def hello():
+\tpass
+
+import json
+"""
+
+DOC_SYNTAX_ERR = """def hello()
+    pass
+"""
+
+DOC_INDENT_ERR = """def hello():
+    x = 1
+  pass
+"""
+
+DOC_ENCODING = u"""# encoding=utf-8
+import sys
+"""
+
+
+def test_jedi_lint(workspace):
+    doc = Document(DOC_URI, workspace, DOC)
+    diags = jedi_lint.pyls_lint(doc)
+
+    assert len(diags) == 0
+
+
+def test_syntax_error_jedi(workspace):
+    doc = Document(DOC_URI, workspace, DOC_SYNTAX_ERR)
+    diag = jedi_lint.pyls_lint(doc)[0]
+
+    assert diag['message'] == 'SyntaxError: invalid syntax'
+    assert diag['range']['start'] == {'line': 0, 'character': 11}
+    assert diag['range']['end'] == {'line': 1, 'character': 0}
+    assert diag['severity'] == lsp.DiagnosticSeverity.Error
+
+
+def test_indent_error_jedi(workspace):
+    doc = Document(DOC_URI, workspace, DOC_INDENT_ERR)
+    diag = jedi_lint.pyls_lint(doc)[0]
+
+    assert diag['message'] == "IndentationError: unindent does not match \
+any outer indentation level"
+    assert diag['range']['start'] == {'line': 2, 'character': 0}
+    assert diag['range']['end'] == {'line': 2, 'character': 2}
+    assert diag['severity'] == lsp.DiagnosticSeverity.Error
+
+
+def test_encoding_jedi(workspace):
+    doc = Document(DOC_URI, workspace, DOC_ENCODING)
+    diags = jedi_lint.pyls_lint(doc)
+
+    assert len(diags) == 0

--- a/test/plugins/test_jedi_lint.py
+++ b/test/plugins/test_jedi_lint.py
@@ -29,7 +29,7 @@ def test_jedi_lint(workspace):
     doc = Document(DOC_URI, workspace, DOC)
     diags = jedi_lint.pyls_lint(doc)
 
-    assert len(diags) == 0
+    assert not diags
 
 
 def test_syntax_error_jedi(workspace):
@@ -57,4 +57,4 @@ def test_encoding_jedi(workspace):
     doc = Document(DOC_URI, workspace, DOC_ENCODING)
     diags = jedi_lint.pyls_lint(doc)
 
-    assert len(diags) == 0
+    assert not diags


### PR DESCRIPTION
This adds a plugin for accessing [Jedi's syntax error detection](https://jedi.readthedocs.io/en/latest/docs/api.html#jedi.Script.get_syntax_errors). From v0.17.0 Jedi provides `Script.get_syntax_errors` to display syntax errors (they only support Syntax and Indent error right now), so I thought it would be nice to have this included in PYLS. 
It's my first PR here, so apologize if I forgot about something obvious, appreciate any comments/suggestions! :)