### PR TITLE
Allow info level logs

### DIFF
--- a/pyls/plugins/pycodestyle_lint.py
+++ b/pyls/plugins/pycodestyle_lint.py
@@ -88,4 +88,3 @@ def _get_severity(code):
         return lsp.DiagnosticSeverity.Warning
     # If no severity is specified, why wouldn't this be informational only?
     return lsp.DiagnosticSeverity.Information
-

--- a/pyls/plugins/pycodestyle_lint.py
+++ b/pyls/plugins/pycodestyle_lint.py
@@ -78,5 +78,13 @@ class PyCodeStyleDiagnosticReport(pycodestyle.BaseReport):
             'message': text,
             'code': code,
             # Are style errors really ever errors?
-            'severity': lsp.DiagnosticSeverity.Warning
+            'severity': _get_severity(code)
         })
+
+
+def _get_severity(code):
+    # Are style errors ever really errors?
+    if code[0] == 'E' or code[0] == 'W':
+        return lsp.DiagnosticSeverity.Warning
+    # If no severity is specified, why wouldn't this be informational only?
+    return lsp.DiagnosticSeverity.Information

--- a/pyls/plugins/pycodestyle_lint.py
+++ b/pyls/plugins/pycodestyle_lint.py
@@ -88,3 +88,4 @@ def _get_severity(code):
         return lsp.DiagnosticSeverity.Warning
     # If no severity is specified, why wouldn't this be informational only?
     return lsp.DiagnosticSeverity.Information
+


### PR DESCRIPTION
Currently all logs, whether error or warning, go straight to warning.

It makes sense that pep8 errors are only warnings, but for any other type of message (and depending on the plugins users might use) there's no reason these need to be fixed to warning level - these could be purely informational.