### PR TITLE
Add document path to Jedi's sys_path 

### DIFF
--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -258,7 +258,7 @@ class Document(object):
         env_vars.pop('PYTHONPATH', None)
 
         environment = self.get_enviroment(environment_path, env_vars=env_vars) if environment_path else None
-        sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths
+        sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths + [os.path.dirname(self.path)]
         project_path = self._workspace.root_path
 
         kwargs = {

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -45,6 +45,15 @@ def workspace(tmpdir):
 
 
 @pytest.fixture
+def workspace_other_root_path(tmpdir):
+    """Return a workspace with a root_path other than tmpdir."""
+    ws_path = str(tmpdir.mkdir('test123').mkdir('test456'))
+    ws = Workspace(uris.from_fs_path(ws_path), Mock())
+    ws._config = Config(ws.root_uri, {}, 0, {})
+    return ws
+
+
+@pytest.fixture
 def config(workspace):  # pylint: disable=redefined-outer-name
     """Return a config object."""
     return Config(workspace.root_uri, {}, 0, {})

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -334,3 +334,26 @@ def test_jedi_completion_environment(workspace):
     completions = pyls_jedi_completions(doc._config, doc, com_position)
     assert completions[0]['label'] == 'loghub'
     assert 'changelog generator' in completions[0]['documentation'].lower()
+
+
+def test_document_path_completions(tmpdir, workspace_other_root_path):
+    # Create a dummy module out of the workspace's root_path and try to get
+    # completions for it in another file placed next to it.
+    module_content = '''
+def foo():
+    pass
+'''
+
+    p = tmpdir.join("mymodule.py")
+    p.write(module_content)
+
+    # Content of doc to test completion
+    doc_content = """import mymodule
+mymodule.f"""
+    doc_path = str(tmpdir) + os.path.sep + 'myfile.py'
+    doc_uri = uris.from_fs_path(doc_path)
+    doc = Document(doc_uri, workspace_other_root_path, doc_content)
+
+    com_position = {'line': 1, 'character': 10}
+    completions = pyls_jedi_completions(doc._config, doc, com_position)
+    assert completions[0]['label'] == 'foo()'


### PR DESCRIPTION
This allows to have completions for files out of the workspace's root_path.

This addresses spyder-ide/spyder#11118