### PR TITLE
Use document path only for completions

### DIFF
--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -57,7 +57,7 @@ def pyls_completions(config, document, position):
     code_position = _utils.position_to_jedi_linecolumn(document, position)
 
     code_position["fuzzy"] = settings.get("fuzzy", False)
-    completions = document.jedi_script().complete(**code_position)
+    completions = document.jedi_script(use_document_path=True).complete(**code_position)
 
     if not completions:
         return None

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -240,7 +240,7 @@ class Document(object):
                                 references=references)
 
     @lock
-    def jedi_script(self, position=None):
+    def jedi_script(self, position=None, use_document_path=False):
         extra_paths = []
         environment_path = None
         env_vars = None
@@ -258,8 +258,12 @@ class Document(object):
         env_vars.pop('PYTHONPATH', None)
 
         environment = self.get_enviroment(environment_path, env_vars=env_vars) if environment_path else None
-        sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths + [os.path.dirname(self.path)]
+        sys_path = self.sys_path(environment_path, env_vars=env_vars) + extra_paths
         project_path = self._workspace.root_path
+
+        # Extend sys_path with document's path if requested
+        if use_document_path:
+            sys_path += [os.path.dirname(self.path)]
 
         kwargs = {
             'code': self.source,


### PR DESCRIPTION
- That was interfering with our plugin to get symbols.
- It could also interfere with other plugins.