### PR TITLE
Pass document path to jedi_names when a file is not placed in a module

### DIFF
--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -1,5 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
+import os
+
 from pyls import hookimpl
 from pyls.lsp import SymbolKind
 
@@ -15,7 +17,13 @@ def pyls_document_symbols(config, document):
     symbols_settings = config.plugin_settings('jedi_symbols')
     all_scopes = symbols_settings.get('all_scopes', True)
     add_import_symbols = symbols_settings.get('include_import_symbols', True)
-    definitions = document.jedi_names(all_scopes=all_scopes)
+
+    use_document_path = False
+    document_dir = os.path.dirname(document.path)
+    if not os.path.isfile(os.path.join(document_dir, '__init__.py')):
+        use_document_path = True
+
+    definitions = document.jedi_names(use_document_path, all_scopes=all_scopes)
     module_name = document.dot_path
     symbols = []
     exclude = set({})

--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -19,7 +19,7 @@ def pyls_document_symbols(config, document):
     add_import_symbols = symbols_settings.get('include_import_symbols', True)
 
     use_document_path = False
-    document_dir = os.path.dirname(document.path)
+    document_dir = os.path.normpath(os.path.dirname(document.path))
     if not os.path.isfile(os.path.join(document_dir, '__init__.py')):
         use_document_path = True
 

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -263,7 +263,7 @@ class Document(object):
 
         # Extend sys_path with document's path if requested
         if use_document_path:
-            sys_path += [os.path.dirname(self.path)]
+            sys_path += [os.path.normpath(os.path.dirname(self.path))]
 
         kwargs = {
             'code': self.source,

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -234,8 +234,8 @@ class Document(object):
         return m_start[0] + m_end[-1]
 
     @lock
-    def jedi_names(self, all_scopes=False, definitions=True, references=False):
-        script = self.jedi_script()
+    def jedi_names(self, use_document_path, all_scopes=False, definitions=True, references=False):
+        script = self.jedi_script(use_document_path=use_document_path)
         return script.get_names(all_scopes=all_scopes, definitions=definitions,
                                 references=references)
 


### PR DESCRIPTION
- This is necessary to solve spyder-ide/spyder#13928.
- With this we can get all symbols for those files instead of a subset of them.
- I couldn't come up with a test for this because we have a lot of customizations in Spyder for the Python language server, but I confirmed this fixes the problem in our side.

*Note*: I added a test for this on the Spyder side (see spyder-ide/spyder#14119).