### PR TITLE
Add code in front of the diagnostic message for flake8

### DIFF
--- a/pyls/plugins/flake8_lint.py
+++ b/pyls/plugins/flake8_lint.py
@@ -144,6 +144,8 @@ def parse_stdout(document, stdout):
         _, line, character, code, msg = parsed_line
         line = int(line) - 1
         character = int(character) - 1
+        # show also the code in message
+        msg = code + ' ' + msg
         diagnostics.append(
             {
                 'source': 'flake8',

--- a/test/plugins/test_flake8_lint.py
+++ b/test/plugins/test_flake8_lint.py
@@ -31,7 +31,7 @@ def temp_document(doc_text, workspace):
 def test_flake8_unsaved(workspace):
     doc = Document('', workspace, DOC)
     diags = flake8_lint.pyls_lint(workspace, doc)
-    msg = 'local variable \'a\' is assigned to but never used'
+    msg = 'F841 local variable \'a\' is assigned to but never used'
     unused_var = [d for d in diags if d['message'] == msg][0]
 
     assert unused_var['source'] == 'flake8'
@@ -45,7 +45,7 @@ def test_flake8_lint(workspace):
     try:
         name, doc = temp_document(DOC, workspace)
         diags = flake8_lint.pyls_lint(workspace, doc)
-        msg = 'local variable \'a\' is assigned to but never used'
+        msg = 'F841 local variable \'a\' is assigned to but never used'
         unused_var = [d for d in diags if d['message'] == msg][0]
 
         assert unused_var['source'] == 'flake8'


### PR DESCRIPTION
For the issue discussed in https://github.com/palantir/python-language-server/issues/884, it would be better to also add the code in front the actual diagnostic message, to make the message style the same as pycodestyle.

Fixes #884.