### PR TITLE
PR: Enable code folding results aggregation

### DIFF
--- a/pyls/hookspecs.py
+++ b/pyls/hookspecs.py
@@ -67,7 +67,7 @@ def pyls_experimental_capabilities(config, workspace):
     pass
 
 
-@hookspec(firstresult=True)
+@hookspec
 def pyls_folding_range(config, workspace, document):
     pass
 


### PR DESCRIPTION
This PR enables other pyls plugins to add their own folding results to the ones computed by the main server. While there exist the possibility of having folding start collisions, plugin creators should prevent this.