### PR TITLE
PR: Fix issues with CIs

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,7 +18,7 @@ jobs:
       OS: 'linux'
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     strategy:
-      fail-fast: false 
+      fail-fast: false
       matrix:
         PYTHON_VERSION: ['3.8', '3.7', '3.6', '2.7']
     timeout-minutes: 10
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.PYTHON_VERSION }} 
+          python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'
       - name: Create Jedi environment for testing
         if: matrix.PYTHON_VERSION != '2.7'
@@ -39,7 +39,7 @@ jobs:
           python3 -m venv /tmp/pyenv
           /tmp/pyenv/bin/python -m pip install loghub
       - run: python -m pip install --upgrade pip setuptools
-      - run: pip install -e .[all] .[test]
+      - run: pip install -e .[all,test]
       - run: py.test -v test/
       - name: Pylint checks
         if: matrix.PYTHON_VERSION == '2.7'

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -39,5 +39,5 @@ jobs:
           python3 -m venv /tmp/pyenv
           /tmp/pyenv/bin/python -m pip install loghub
       - run: python -m pip install --upgrade pip setuptools
-      - run: pip install -e .[all] .[test]
+      - run: pip install -e .[all,test]
       - run: py.test -v test/

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -18,7 +18,7 @@ jobs:
       OS: 'win'
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     strategy:
-      fail-fast: false 
+      fail-fast: false
       matrix:
         PYTHON_VERSION: ['3.8', '3.7', '3.6', '2.7']
     timeout-minutes: 10
@@ -31,8 +31,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.PYTHON_VERSION }} 
+          python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: 'x64'
       - run: python -m pip install --upgrade pip setuptools
-      - run: pip install -e .[all] .[test]
+      - run: pip install -e .[all,test]
       - run: py.test -v test/


### PR DESCRIPTION
The latest pip dependency solver raised some errors when trying to install the runtime and test dependencies separately via `pip install -e .[all], .[test]`. This PR fixes this issue by installing both dependency groups simultaneously via `pip install -e .[all,test]`