### PR TITLE
Fix simple typo

### DIFF
--- a/pyls/plugins/folding.py
+++ b/pyls/plugins/folding.py
@@ -179,7 +179,7 @@ def __compute_folding_ranges(tree, lines):
             # Skip newline nodes
             continue
         elif isinstance(node, tree_nodes.PythonErrorNode):
-            # Fallback to identation-based (best-effort) folding
+            # Fallback to indentation-based (best-effort) folding
             start_line, _ = node.start_pos
             start_line -= 1
             padding = [''] * start_line


### PR DESCRIPTION
There is a small typo in pyls/plugins/folding.py.

Should read `indentation` rather than `identation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md