### PR TITLE
bump jedi compatibility: compare to Path-like object

### DIFF
--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -37,7 +37,7 @@ def pyls_document_symbols(config, document):
                         not sym_full_name.startswith('__main__')):
                     continue
 
-        if _include_def(d) and document.path == d.module_path:
+        if _include_def(d) and os.path.samefile(document.path, d.module_path):
             tuple_range = _tuple_range(d)
             if tuple_range in exclude:
                 continue

--- a/pyls/plugins/symbols.py
+++ b/pyls/plugins/symbols.py
@@ -36,8 +36,14 @@ def pyls_document_symbols(config, document):
                 if (not sym_full_name.startswith(module_name) and
                         not sym_full_name.startswith('__main__')):
                     continue
+        try:
+            docismodule = os.path.samefile(document.path, d.module_path)
+        except AttributeError:
+            # Python 2 on Windows has no .samefile, but then these are
+            # strings for sure
+            docismodule = document.path == d.module_path
 
-        if _include_def(d) and os.path.samefile(document.path, d.module_path):
+        if _include_def(d) and docismodule:
             tuple_range = _tuple_range(d)
             if tuple_range in exclude:
                 continue

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
         'configparser; python_version<"3.0"',
         'future>=0.14.0; python_version<"3"',
         'backports.functools_lru_cache; python_version<"3.2"',
-        'jedi>=0.17.2,<0.18.0',
+        'jedi>=0.17.2,<0.19.0',
         'python-jsonrpc-server>=0.4.0',
         'pluggy',
         'ujson<=2.0.3 ; platform_system!="Windows" and python_version<"3.0"',


### PR DESCRIPTION
In the hope that this does not turn into the same disaster as last time (#744, #781), here is a small fix to support the newest Jedi with changed API: Jedi now returns Pathlib objects everywhere. To work with that, you need to compare paths not as strings but as Path-like objects.

Fixes #898