### PR TITLE
917 Update jedi to v0.18.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
         'configparser; python_version<"3.0"',
         'future>=0.14.0; python_version<"3"',
         'backports.functools_lru_cache; python_version<"3.2"',
-        'jedi>=0.17.2,<0.18.0',
+        'jedi>=0.17.2',
         'python-jsonrpc-server>=0.4.0',
         'pluggy',
         'ujson<=2.0.3 ; platform_system!="Windows" and python_version<"3.0"',


### PR DESCRIPTION
This drops support for python 2 and 3.5
resolves #917 