### PR TITLE
Log local timezone if available

### DIFF
--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 import logging.config
 import sys
+import time
 
 try:
     import ujson as json
@@ -12,7 +13,8 @@ except Exception:  # pylint: disable=broad-except
 from .python_ls import (PythonLanguageServer, start_io_lang_server,
                         start_tcp_lang_server)
 
-LOG_FORMAT = "%(asctime)s UTC - %(levelname)s - %(name)s - %(message)s"
+LOG_FORMAT = "%(asctime)s {0} - %(levelname)s - %(name)s - %(message)s".format(
+    time.localtime().tm_zone if sys.version_info >= (3, 3) else "")
 
 
 def add_arguments(parser):


### PR DESCRIPTION
I’ve wrongly removed the forked repository and cannot update #748 any more.
Timezone is used *if available* (compatible with python2).