### PR TITLE
Avoid tracebacks from untracked files

### DIFF
--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -291,7 +291,7 @@ class PythonLanguageServer(MethodDispatcher):
 
     def m_text_document__did_close(self, textDocument=None, **_kwargs):
         workspace = self._match_uri_to_workspace(textDocument['uri'])
-        workspace.rm_document(textDocument['uri'])
+        workspace.rm_maybe_document(textDocument['uri'])
 
     def m_text_document__did_open(self, textDocument=None, **_kwargs):
         workspace = self._match_uri_to_workspace(textDocument['uri'])

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -88,8 +88,8 @@ class Workspace(object):
     def put_document(self, doc_uri, source, version=None):
         self._docs[doc_uri] = self._create_document(doc_uri, source=source, version=version)
 
-    def rm_document(self, doc_uri):
-        self._docs.pop(doc_uri)
+    def rm_maybe_document(self, doc_uri):
+        self._docs.pop(doc_uri, None)
 
     def update_document(self, doc_uri, change, version=None):
         self._docs[doc_uri].apply_change(change)


### PR DESCRIPTION
Sometimes it is possible that a file is not actually being tracked (e.g. when using a plugin such as vim-fugitive), resulting in a traceback when trying to pop its info from the _docs. Avoid this by supplying a default to `_docs.pop()`.