### PR TITLE
Prefer yapf over autopep8

### DIFF
--- a/pyls/plugins/autopep8_format.py
+++ b/pyls/plugins/autopep8_format.py
@@ -7,13 +7,13 @@ from pyls import hookimpl
 log = logging.getLogger(__name__)
 
 
-@hookimpl(tryfirst=True)  # Prefer autopep8 over YAPF
+@hookimpl
 def pyls_format_document(config, document):
     log.info("Formatting document %s with autopep8", document)
     return _format(config, document)
 
 
-@hookimpl(tryfirst=True)  # Prefer autopep8 over YAPF
+@hookimpl
 def pyls_format_range(config, document, range):  # pylint: disable=redefined-builtin
     log.info("Formatting document %s in range %s with autopep8", document, range)
 

--- a/pyls/plugins/yapf_format.py
+++ b/pyls/plugins/yapf_format.py
@@ -8,12 +8,12 @@ from pyls import hookimpl
 log = logging.getLogger(__name__)
 
 
-@hookimpl
+@hookimpl(tryfirst=True)  # Prefer YAPF over autopep8 if available
 def pyls_format_document(document):
     return _format(document)
 
 
-@hookimpl
+@hookimpl(tryfirst=True)  # Prefer YAPF over autopep8 if available
 def pyls_format_range(document, range):  # pylint: disable=redefined-builtin
     # First we 'round' the range up/down to full lines only
     range['start']['character'] = 0


### PR DESCRIPTION
There are mentions in issues such as https://github.com/palantir/python-language-server/issues/328#issue-311406218 about people wanting to switch to yapf as a default instead of autopep8.

This does just that, I also plan on adding options and diffs support to yapf.