### PR TITLE
Add license to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     url='https://github.com/palantir/python-language-server',
 
     author='Palantir Technologies, Inc.',
+    license='MIT',
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().


### PR DESCRIPTION
Currently, when the package is checked for license it shows none, e.g.
```
$ pip install pip-licenses
$ pip-licenses -p python-language-server
 Name                    Version                        License 
 python-language-server  0+untagged.317.ga91a257.dirty  UNKNOWN 
```

After this change
```
$ pip-licenses -p python-language-server
 Name                    Version                        License 
 python-language-server  0+untagged.317.ga91a257.dirty  MIT
```